### PR TITLE
feat: :sparkles: All the content types (besides models)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "sharp": "0.34.2",
+    "slugify": "^1.6.6",
     "word-counting": "^1.1.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       sharp:
         specifier: 0.34.2
         version: 0.34.2
+      slugify:
+        specifier: ^1.6.6
+        version: 1.6.6
       word-counting:
         specifier: ^1.1.4
         version: 1.1.4
@@ -4685,6 +4688,10 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  slugify@1.6.6:
+    resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
+    engines: {node: '>=8.0.0'}
 
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
@@ -11077,6 +11084,8 @@ snapshots:
   simple-wcswidth@1.0.1: {}
 
   sisteransi@1.0.5: {}
+
+  slugify@1.6.6: {}
 
   sonic-boom@4.2.0:
     dependencies:

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,6 +6,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  enabled: process.env.NODE_ENV === 'production',
   dsn: 'https://8ef8d319359fca409a608a58701e7ae8@o199789.ingest.us.sentry.io/4509274464583680',
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,6 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  enabled: process.env.NODE_ENV === 'production',
   dsn: 'https://8ef8d319359fca409a608a58701e7ae8@o199789.ingest.us.sentry.io/4509274464583680',
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.

--- a/src/collections/Gallery/Album/index.ts
+++ b/src/collections/Gallery/Album/index.ts
@@ -52,6 +52,14 @@ export const GalleryAlbums: CollectionConfig<'gallery-albums'> = {
           label: 'Is NSFW?',
         },
         {
+          name: 'category',
+          type: 'relationship',
+          relationTo: 'gallery-categories',
+          admin: {
+            position: 'sidebar',
+          },
+        },
+        {
           name: 'tags',
           type: 'relationship',
           relationTo: 'gallery-tags',

--- a/src/collections/Gallery/Categories/index.ts
+++ b/src/collections/Gallery/Categories/index.ts
@@ -2,20 +2,19 @@ import { RBAC } from '@/access/RBAC';
 import { slugField } from '@/fields/slug';
 import { CollectionConfig } from 'payload';
 
-export const Manufacturers: CollectionConfig<'manufacturers'> = {
-  slug: 'manufacturers',
-  access: RBAC('manufacturers'),
+export const GalleryCategories: CollectionConfig<'gallery-categories'> = {
+  slug: 'gallery-categories',
+  access: RBAC('gallery-categories'),
   admin: {
     useAsTitle: 'title',
-    group: 'Models',
-    description: 'Model kit manufacturers',
+    group: 'Gallery',
+    description: 'Gallery categories.  Primary method of filtering galleries.',
   },
   fields: [
     {
       name: 'title',
       type: 'text',
       required: true,
-      label: 'Brand Name',
     },
     ...slugField(),
   ],

--- a/src/collections/Gardens.ts
+++ b/src/collections/Gardens.ts
@@ -1,0 +1,83 @@
+import { RBAC } from '@/access/RBAC';
+import { slugField } from '@/fields/slug';
+import {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
+} from '@payloadcms/plugin-seo/fields';
+import { lexicalEditor } from '@payloadcms/richtext-lexical';
+import { CollectionConfig } from 'payload';
+
+export const Gardens: CollectionConfig<'gardens'> = {
+  slug: 'gardens',
+  access: RBAC('gardens'),
+  admin: {
+    useAsTitle: 'name',
+    group: 'Miscellaneous',
+    description: "Other things that don't have a spcecific home",
+  },
+  fields: [
+    ...slugField('name'),
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'Content',
+          fields: [
+            {
+              name: 'name',
+              type: 'text',
+              required: true,
+            },
+            {
+              name: 'featuredImage',
+              type: 'upload',
+              relationTo: 'media',
+            },
+            {
+              name: 'content',
+              type: 'richText',
+              editor: lexicalEditor({
+                features: ({ rootFeatures }) => {
+                  return [...rootFeatures];
+                },
+              }),
+            },
+          ],
+        },
+        {
+          label: 'SEO',
+          fields: [
+            OverviewField({
+              titlePath: 'meta.title',
+              descriptionPath: 'meta.description',
+              imagePath: 'meta.image',
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaDescriptionField({
+              hasGenerateFn: true,
+            }),
+            MetaImageField({
+              hasGenerateFn: true,
+              relationTo: 'media',
+              overrides: {
+                admin: {
+                  allowCreate: true,
+                },
+              },
+            }),
+            PreviewField({
+              hasGenerateFn: false,
+              titlePath: 'meta.title',
+              descriptionPath: 'meta.description',
+            }),
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/src/collections/Models/Kits/index.ts
+++ b/src/collections/Models/Kits/index.ts
@@ -16,16 +16,39 @@ export const Kits: CollectionConfig<'kits'> = {
       required: true,
     },
     {
+      name: 'kit_number',
+      type: 'text',
+      required: true,
+      label: "Manufacturer's Kit Number",
+    },
+    {
+      name: 'year_released',
+      type: 'number',
+      required: true,
+      defaultValue: new Date().getFullYear(),
+    },
+    {
+      name: 'scalemates',
+      type: 'text',
+      label: 'Scalemates link',
+    },
+    {
       name: 'manufacturer',
       type: 'relationship',
       relationTo: 'manufacturers',
       required: true,
+      admin: {
+        position: 'sidebar',
+      },
     },
     {
       name: 'scale',
       type: 'relationship',
       relationTo: 'scales',
       required: true,
+      admin: {
+        position: 'sidebar',
+      },
     },
   ],
 };

--- a/src/collections/Models/Scales/index.ts
+++ b/src/collections/Models/Scales/index.ts
@@ -15,7 +15,8 @@ export const Scales: CollectionConfig<'scales'> = {
       name: 'title',
       type: 'text',
       required: true,
+      label: 'Scale',
     },
-    ...slugField(),
+    ...slugField('title'),
   ],
 };

--- a/src/collections/Models/Tags/index.ts
+++ b/src/collections/Models/Tags/index.ts
@@ -2,20 +2,19 @@ import { RBAC } from '@/access/RBAC';
 import { slugField } from '@/fields/slug';
 import { CollectionConfig } from 'payload';
 
-export const Manufacturers: CollectionConfig<'manufacturers'> = {
-  slug: 'manufacturers',
-  access: RBAC('manufacturers'),
+export const ModelsTags: CollectionConfig<'models-tags'> = {
+  slug: 'models-tags',
+  access: RBAC('models-tags'),
   admin: {
     useAsTitle: 'title',
     group: 'Models',
-    description: 'Model kit manufacturers',
+    description: 'Models tags.  Used for more focused classification of models.',
   },
   fields: [
     {
       name: 'title',
       type: 'text',
       required: true,
-      label: 'Brand Name',
     },
     ...slugField(),
   ],

--- a/src/fields/slug/formatSlug.ts
+++ b/src/fields/slug/formatSlug.ts
@@ -1,25 +1,23 @@
-import type { FieldHook } from 'payload'
+import type { FieldHook } from 'payload';
+import slugify from 'slugify';
 
 export const formatSlug = (val: string): string =>
-  val
-    .replace(/ /g, '-')
-    .replace(/[^\w-]+/g, '')
-    .toLowerCase()
+  slugify(val.replace(/\//g, '-'), { lower: true });
 
 export const formatSlugHook =
   (fallback: string): FieldHook =>
   ({ data, operation, value }) => {
     if (typeof value === 'string') {
-      return formatSlug(value)
+      return formatSlug(value);
     }
 
     if (operation === 'create' || !data?.slug) {
-      const fallbackData = data?.[fallback] || data?.[fallback]
+      const fallbackData = data?.[fallback] || data?.[fallback];
 
       if (fallbackData && typeof fallbackData === 'string') {
-        return formatSlug(fallbackData)
+        return formatSlug(fallbackData);
       }
     }
 
-    return value
-  }
+    return value;
+  };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -77,9 +77,12 @@ export interface Config {
     'gallery-albums': GalleryAlbum;
     'gallery-images': GalleryImage;
     'gallery-tags': GalleryTag;
+    'gallery-categories': GalleryCategory;
+    gardens: Garden;
     kits: Kit;
     scales: Scale;
     manufacturers: Manufacturer;
+    'models-tags': ModelsTag;
     forms: Form;
     'form-submissions': FormSubmission;
     search: Search;
@@ -112,9 +115,12 @@ export interface Config {
     'gallery-albums': GalleryAlbumsSelect<false> | GalleryAlbumsSelect<true>;
     'gallery-images': GalleryImagesSelect<false> | GalleryImagesSelect<true>;
     'gallery-tags': GalleryTagsSelect<false> | GalleryTagsSelect<true>;
+    'gallery-categories': GalleryCategoriesSelect<false> | GalleryCategoriesSelect<true>;
+    gardens: GardensSelect<false> | GardensSelect<true>;
     kits: KitsSelect<false> | KitsSelect<true>;
     scales: ScalesSelect<false> | ScalesSelect<true>;
     manufacturers: ManufacturersSelect<false> | ManufacturersSelect<true>;
+    'models-tags': ModelsTagsSelect<false> | ModelsTagsSelect<true>;
     forms: FormsSelect<false> | FormsSelect<true>;
     'form-submissions': FormSubmissionsSelect<false> | FormSubmissionsSelect<true>;
     search: SearchSelect<false> | SearchSelect<true>;
@@ -394,6 +400,7 @@ export interface GalleryAlbum {
     slug?: string | null;
     slugLock?: boolean | null;
     isNsfw?: boolean | null;
+    category?: (number | null) | GalleryCategory;
     tags?: (number | GalleryTag)[] | null;
     visibility: 'ALL' | 'AUTHENTICATED' | 'PRIVILEGED';
     allowedRoles?: (number | Role)[] | null;
@@ -428,6 +435,20 @@ export interface GalleryAlbum {
     image?: (number | null) | Media;
     description?: string | null;
   };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Gallery categories.  Primary method of filtering galleries.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "gallery-categories".
+ */
+export interface GalleryCategory {
+  id: number;
+  title: string;
+  slug?: string | null;
+  slugLock?: boolean | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -571,6 +592,39 @@ export interface Page {
   _status?: ('draft' | 'published') | null;
 }
 /**
+ * Other things that don't have a spcecific home
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "gardens".
+ */
+export interface Garden {
+  id: number;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  name: string;
+  featuredImage?: (number | null) | Media;
+  content?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  title?: string | null;
+  description?: string | null;
+  image?: (number | null) | Media;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * Model Kits
  *
  * This interface was referenced by `Config`'s JSON-Schema
@@ -579,6 +633,9 @@ export interface Page {
 export interface Kit {
   id: number;
   title: string;
+  kit_number: string;
+  year_released: number;
+  scalemates?: string | null;
   manufacturer: number | Manufacturer;
   scale: number | Scale;
   updatedAt: string;
@@ -605,6 +662,20 @@ export interface Manufacturer {
  * via the `definition` "scales".
  */
 export interface Scale {
+  id: number;
+  title: string;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Models tags.  Used for more focused classification of models.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "models-tags".
+ */
+export interface ModelsTag {
   id: number;
   title: string;
   slug?: string | null;
@@ -965,6 +1036,14 @@ export interface PayloadLockedDocument {
         value: number | GalleryTag;
       } | null)
     | ({
+        relationTo: 'gallery-categories';
+        value: number | GalleryCategory;
+      } | null)
+    | ({
+        relationTo: 'gardens';
+        value: number | Garden;
+      } | null)
+    | ({
         relationTo: 'kits';
         value: number | Kit;
       } | null)
@@ -975,6 +1054,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'manufacturers';
         value: number | Manufacturer;
+      } | null)
+    | ({
+        relationTo: 'models-tags';
+        value: number | ModelsTag;
       } | null)
     | ({
         relationTo: 'forms';
@@ -1252,6 +1335,7 @@ export interface GalleryAlbumsSelect<T extends boolean = true> {
         slug?: T;
         slugLock?: T;
         isNsfw?: T;
+        category?: T;
         tags?: T;
         visibility?: T;
         allowedRoles?: T;
@@ -1317,10 +1401,40 @@ export interface GalleryTagsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "gallery-categories_select".
+ */
+export interface GalleryCategoriesSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  slugLock?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "gardens_select".
+ */
+export interface GardensSelect<T extends boolean = true> {
+  slug?: T;
+  slugLock?: T;
+  name?: T;
+  featuredImage?: T;
+  content?: T;
+  title?: T;
+  description?: T;
+  image?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "kits_select".
  */
 export interface KitsSelect<T extends boolean = true> {
   title?: T;
+  kit_number?: T;
+  year_released?: T;
+  scalemates?: T;
   manufacturer?: T;
   scale?: T;
   updatedAt?: T;
@@ -1342,6 +1456,17 @@ export interface ScalesSelect<T extends boolean = true> {
  * via the `definition` "manufacturers_select".
  */
 export interface ManufacturersSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  slugLock?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "models-tags_select".
+ */
+export interface ModelsTagsSelect<T extends boolean = true> {
   title?: T;
   slug?: T;
   slugLock?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -7,12 +7,15 @@ import { fileURLToPath } from 'url';
 
 import { resendAdapter } from '@payloadcms/email-resend';
 import { GalleryAlbums } from './collections/Gallery/Album';
+import { GalleryCategories } from './collections/Gallery/Categories';
 import { GalleryImages } from './collections/Gallery/Image';
 import { GalleryTags } from './collections/Gallery/Tags';
+import { Gardens } from './collections/Gardens';
 import { Media } from './collections/Media/Media';
 import { Kits } from './collections/Models/Kits';
 import { Manufacturers } from './collections/Models/Manufacturers';
 import { Scales } from './collections/Models/Scales';
+import { ModelsTags } from './collections/Models/Tags';
 import { Pages } from './collections/Pages';
 import { PostsCategories } from './collections/Posts/Categories';
 import { Posts } from './collections/Posts/Posts';
@@ -54,9 +57,12 @@ export default buildConfig({
     GalleryAlbums,
     GalleryImages,
     GalleryTags,
+    GalleryCategories,
+    Gardens,
     Kits,
     Scales,
     Manufacturers,
+    ModelsTags,
   ],
   editor: defaultLexical,
   secret: process.env.PAYLOAD_SECRET || '',

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -26,7 +26,7 @@ export const plugins: Plugin[] = [
   }),
   seoPlugin({
     generateTitle: ({ doc }) => {
-      return doc?.title ? `${doc.title} | ItsMillerTime` : 'ItsMillerTime';
+      return `${doc?.title || doc?.name || 'Default'} | ItsMillerTime`;
     },
     generateURL: ({ doc }) => {
       const url = getServerSideURL();


### PR DESCRIPTION
The following content types were added

- gallery categories
- kits
- scales
- manufacturers
- model tags
- gardens

Updated the slugify function to use slugify, but also adjusted to allow for backslashes, as they are used in models and i prefer them to be there.

Sentry only enabled on production now as well