### PR TITLE
Add default populate setting for EXIF metadata in Media collection

### DIFF
--- a/src/collections/Media/Media.ts
+++ b/src/collections/Media/Media.ts
@@ -17,6 +17,9 @@ export const Media: CollectionConfig = {
     description: 'Media Items, images and otherwise',
     defaultColumns: ['alt', 'caption'],
   },
+  defaultPopulate: {
+    exif: false,
+  },
   folders: true,
   access: RBAC('media'),
   fields: [


### PR DESCRIPTION
This PR adds a defaultPopulate configuration to the Media collection to exclude EXIF metadata by default, which can help improve performance by not loading unnecessary metadata unless explicitly requested.