### PR TITLE
feat: gallery image tracking endpoint and deploy version badge (3.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # cms-itsmillertime-dev
 
+## 3.18.0
+
+### Minor Changes
+
+- Add gallery image tracking endpoint for anonymous lightbox engagement updates
+- Show deployed CMS version in the admin sidebar
+
 ## 3.10.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-itsmillertime-dev",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -55,6 +55,7 @@ import { WebhookCollectionRowLabel as WebhookCollectionRowLabel_fcb2dafdf0f59a6c
 import { CustomNav as CustomNav_7a25bf58b9bf0789c79437d44273b9e5 } from 'payload-sidebar-plugin/rsc'
 import { LogoutButton as LogoutButton_aa8e4427b70b37c7820895ace344eb78 } from '@delmaredigital/payload-better-auth/components'
 import { SearchButton as SearchButton_3bf5d3e334c5eaf4f0d216451590d3c2 } from '@veiag/payload-cmdk/client'
+import { default as default_b6d8c610b4d95791d45b9341cff87ac1 } from '@/components/DeployVersion'
 import { SecurityNavLinks as SecurityNavLinks_e3642e6c1e5dbb92bcf178f42e87e19e } from '@delmaredigital/payload-better-auth/components/management'
 import { BeforeLogin as BeforeLogin_aa8e4427b70b37c7820895ace344eb78 } from '@delmaredigital/payload-better-auth/components'
 import { default as default_e5727cf75af5a5f3715e1efb9b6b07eb } from '@/components/NavBadgeProvider'
@@ -126,6 +127,7 @@ export const importMap = {
   "payload-sidebar-plugin/rsc#CustomNav": CustomNav_7a25bf58b9bf0789c79437d44273b9e5,
   "@delmaredigital/payload-better-auth/components#LogoutButton": LogoutButton_aa8e4427b70b37c7820895ace344eb78,
   "@veiag/payload-cmdk/client#SearchButton": SearchButton_3bf5d3e334c5eaf4f0d216451590d3c2,
+  "@/components/DeployVersion#default": default_b6d8c610b4d95791d45b9341cff87ac1,
   "@delmaredigital/payload-better-auth/components/management#SecurityNavLinks": SecurityNavLinks_e3642e6c1e5dbb92bcf178f42e87e19e,
   "@delmaredigital/payload-better-auth/components#BeforeLogin": BeforeLogin_aa8e4427b70b37c7820895ace344eb78,
   "@/components/NavBadgeProvider#default": default_e5727cf75af5a5f3715e1efb9b6b07eb,

--- a/src/app/(payload)/custom.scss
+++ b/src/app/(payload)/custom.scss
@@ -1,0 +1,23 @@
+.deploy-version {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin: 0.75rem var(--gutter-h, 1rem) 0;
+  padding: 0.625rem 0.75rem;
+  border-top: 1px solid var(--theme-elevation-150, #e5e7eb);
+  font-size: 0.75rem;
+  line-height: 1.2;
+}
+
+.deploy-version__label {
+  color: var(--theme-elevation-500, #6b7280);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.deploy-version__value {
+  color: var(--theme-elevation-800, #1f2937);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}

--- a/src/components/DeployVersion/index.tsx
+++ b/src/components/DeployVersion/index.tsx
@@ -1,0 +1,10 @@
+import packageJson from '../../../package.json';
+
+export default function DeployVersion() {
+  return (
+    <div className="deploy-version">
+      <span className="deploy-version__label">Deployed</span>
+      <span className="deploy-version__value">v{packageJson.version}</span>
+    </div>
+  );
+}

--- a/src/endpoints/gallery-image-tracking.ts
+++ b/src/endpoints/gallery-image-tracking.ts
@@ -1,0 +1,88 @@
+import type { PayloadRequest } from 'payload';
+
+const TRACKING_EVENTS = ['view', 'download', 'like', 'dislike', 'share'] as const;
+type TrackingEvent = (typeof TRACKING_EVENTS)[number];
+
+const EVENT_TO_FIELD = {
+  view: 'views',
+  download: 'downloads',
+  like: 'likes',
+  dislike: 'dislikes',
+  share: 'shares',
+} as const;
+
+function normalizeTracking(tracking: Record<string, unknown> | null | undefined) {
+  return {
+    views: typeof tracking?.views === 'number' ? tracking.views : 0,
+    downloads: typeof tracking?.downloads === 'number' ? tracking.downloads : 0,
+    likes: typeof tracking?.likes === 'number' ? tracking.likes : 0,
+    dislikes: typeof tracking?.dislikes === 'number' ? tracking.dislikes : 0,
+    comments: typeof tracking?.comments === 'number' ? tracking.comments : 0,
+    shares: typeof tracking?.shares === 'number' ? tracking.shares : 0,
+  };
+}
+
+export async function galleryImageTrackingHandler(req: PayloadRequest): Promise<Response> {
+  if (req.method !== 'POST') {
+    return Response.json({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const parseJson = req.json;
+  if (!parseJson) {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await parseJson.call(req);
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { id, event } = body as Record<string, unknown>;
+  const galleryImageId = Number(id);
+
+  if (!Number.isFinite(galleryImageId) || galleryImageId <= 0) {
+    return Response.json({ error: 'Invalid gallery image id' }, { status: 400 });
+  }
+
+  if (typeof event !== 'string' || !TRACKING_EVENTS.includes(event as TrackingEvent)) {
+    return Response.json({ error: 'Invalid tracking event' }, { status: 400 });
+  }
+
+  const field = EVENT_TO_FIELD[event as TrackingEvent];
+
+  try {
+    const existing = await req.payload.findByID({
+      collection: 'gallery-images',
+      id: galleryImageId,
+      depth: 0,
+      overrideAccess: true,
+    });
+
+    if (!existing) {
+      return Response.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const current = normalizeTracking(
+      (existing.tracking as Record<string, unknown> | null | undefined) ?? undefined,
+    );
+    const nextTracking = { ...current, [field]: current[field] + 1 };
+
+    const updated = await req.payload.update({
+      collection: 'gallery-images',
+      id: galleryImageId,
+      data: { tracking: nextTracking },
+      overrideAccess: true,
+    });
+
+    return Response.json({ tracking: normalizeTracking(updated.tracking ?? undefined) });
+  } catch (err) {
+    console.error('[gallery-image-tracking]', err);
+    return Response.json({ error: 'Failed to update tracking' }, { status: 500 });
+  }
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -40,6 +40,7 @@ import { safeEmailSubjectLine } from './utilities/sanitizeContactForm';
 import { ResetPasswordEmail } from '../emails/reset-password';
 import { VerifyAccountEmail } from '../emails/verify-account';
 import { contactFormHandler } from './endpoints/contact-form';
+import { galleryImageTrackingHandler } from './endpoints/gallery-image-tracking';
 import { trustedOriginsArray } from './lib/auth/trustedOrigins';
 
 const filename = fileURLToPath(import.meta.url);
@@ -86,6 +87,11 @@ export default buildConfig({
       path: '/contact-form',
       method: 'post',
       handler: contactFormHandler,
+    },
+    {
+      path: '/gallery-image-tracking',
+      method: 'post',
+      handler: galleryImageTrackingHandler,
     },
   ],
   kv: redisKVAdapter({

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -186,6 +186,7 @@ export default buildConfig({
       ],
     },
     components: {
+      afterNavLinks: ['@/components/DeployVersion'],
       providers: ['@/components/NavBadgeProvider'],
       views: {
         bgg: {


### PR DESCRIPTION
## Summary
- Add `POST /api/gallery-image-tracking` so the public site can increment gallery image engagement counters without authenticated `PATCH` access to `gallery-images`.
- Show the deployed CMS version (`v3.18.0`) in the admin sidebar above logout, making it easy to confirm new deploys landed.
- Bump package version to **3.18.0** with changelog entry.

## Test plan
- [ ] Restart CMS and `curl -X POST http://localhost:3000/api/gallery-image-tracking -H 'Content-Type: application/json' -d '{"id":<real-id>,"event":"view"}'` returns `200` with updated `tracking`
- [ ] Invalid event returns `400`; missing image returns `404`
- [ ] Open gallery lightbox on the site and confirm `POST /api/gallery/images/<id>/tracking` returns `200` (not `502`)
- [ ] Open Payload admin and confirm **Deployed v3.18.0** appears at the bottom of the sidebar above logout
- [ ] After deploy, verify the sidebar version updates to match the new release


Made with [Cursor](https://cursor.com)