### PR TITLE
3.21.2 — fix Medusa offering-set apply (reject price fields)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-itsmillertime-dev",
-  "version": "3.21.2",
+  "version": "3.21.3",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-itsmillertime-dev",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/lib/medusa/client.ts
+++ b/src/lib/medusa/client.ts
@@ -561,19 +561,16 @@ async function applyOfferingSet(
   env: MedusaEnv,
   productId: string,
   offeringSetId: string,
-  input: Pick<ProductInput, 'sellsDigital' | 'digitalPriceUSD'>,
+  input: Pick<ProductInput, 'sellsDigital'>,
 ): Promise<void> {
+  // The backend route only accepts offering_set_id + sells_digital (it rejects
+  // any price fields). The digital variant's price is set separately via a
+  // standard variant update after the workflow creates it.
   await adminFetch(env, `/admin/products/${productId}/offering-set`, {
     method: 'POST',
     body: JSON.stringify({
       offering_set_id: offeringSetId,
       sells_digital: input.sellsDigital,
-      ...(input.sellsDigital && input.digitalPriceUSD != null && input.digitalPriceUSD > 0
-        ? {
-            digital_price: input.digitalPriceUSD,
-            digital_price_currency: env.currency,
-          }
-        : {}),
     }),
   });
 }
@@ -705,12 +702,18 @@ export async function createProduct(env: MedusaEnv, input: ProductInput): Promis
     throw new Error(`Product ${product.id} disappeared after creation.`);
   }
 
-  // Apply-created digital variants have no SKU; backfill it for parity with
-  // the digital-only path.
+  // The offering-set workflow creates the digital variant without our SKU or
+  // price (the route rejects price fields), so backfill both via a standard
+  // variant update. Inline digital-only variants already have them.
   if (input.sellsDigital && created.variantId && !created.sku) {
     await adminFetch(env, `/admin/products/${product.id}/variants/${created.variantId}`, {
       method: 'POST',
-      body: JSON.stringify({ sku: input.sku || `GALLERY-IMG-${input.galleryImageId}` }),
+      body: JSON.stringify({
+        sku: input.sku || `GALLERY-IMG-${input.galleryImageId}`,
+        ...(input.digitalPriceUSD != null && input.digitalPriceUSD > 0
+          ? { prices: [{ amount: input.digitalPriceUSD, currency_code: env.currency }] }
+          : {}),
+      }),
     });
     return (await getProduct(env, product.id)) ?? created;
   }

--- a/src/lib/medusa/client.ts
+++ b/src/lib/medusa/client.ts
@@ -561,16 +561,21 @@ async function applyOfferingSet(
   env: MedusaEnv,
   productId: string,
   offeringSetId: string,
-  input: Pick<ProductInput, 'sellsDigital'>,
+  input: Pick<ProductInput, 'sellsDigital' | 'digitalPriceUSD'>,
 ): Promise<void> {
-  // The backend route only accepts offering_set_id + sells_digital (it rejects
-  // any price fields). The digital variant's price is set separately via a
-  // standard variant update after the workflow creates it.
+  // The workflow prices the digital variant from `digital_price`, so send it
+  // (and the currency) alongside `sells_digital` when there's a digital price.
   await adminFetch(env, `/admin/products/${productId}/offering-set`, {
     method: 'POST',
     body: JSON.stringify({
       offering_set_id: offeringSetId,
       sells_digital: input.sellsDigital,
+      ...(input.sellsDigital && input.digitalPriceUSD != null && input.digitalPriceUSD > 0
+        ? {
+            digital_price: input.digitalPriceUSD,
+            digital_price_currency: env.currency,
+          }
+        : {}),
     }),
   });
 }
@@ -702,18 +707,12 @@ export async function createProduct(env: MedusaEnv, input: ProductInput): Promis
     throw new Error(`Product ${product.id} disappeared after creation.`);
   }
 
-  // The offering-set workflow creates the digital variant without our SKU or
-  // price (the route rejects price fields), so backfill both via a standard
-  // variant update. Inline digital-only variants already have them.
+  // The offering-set workflow prices the digital variant but doesn't give it a
+  // SKU; backfill the SKU for parity with the inline digital-only path.
   if (input.sellsDigital && created.variantId && !created.sku) {
     await adminFetch(env, `/admin/products/${product.id}/variants/${created.variantId}`, {
       method: 'POST',
-      body: JSON.stringify({
-        sku: input.sku || `GALLERY-IMG-${input.galleryImageId}`,
-        ...(input.digitalPriceUSD != null && input.digitalPriceUSD > 0
-          ? { prices: [{ amount: input.digitalPriceUSD, currency_code: env.currency }] }
-          : {}),
-      }),
+      body: JSON.stringify({ sku: input.sku || `GALLERY-IMG-${input.galleryImageId}` }),
     });
     return (await getProduct(env, product.id)) ?? created;
   }


### PR DESCRIPTION
## Summary
Follow-up to #116. With the product-create `options` fix deployed, `POST /admin/products` now succeeds, but the next call — `POST /admin/products/:id/offering-set` — fails:

```
Invalid request: Unrecognized fields: 'digital_price, digital_price_currency'
POST /admin/products/:id/offering-set -> 400
```

The backend's offering-set route uses strict validation and only accepts `offering_set_id` and `sells_digital`. This PR:
- Removes `digital_price`/`digital_price_currency` from the `applyOfferingSet` body.
- Sets the digital variant's price via a standard variant update after the `sells_digital` workflow creates it (the create flow now backfills SKU **and** price; the update flow already set the price).

## Test plan
- [ ] List a gallery image with a print offering set + digital enabled → product creates, offering set applies (no 400), and the digital variant has the correct price.
- [ ] List with a print offering set + digital disabled → applies without a digital variant.
- [ ] Digital-only listing still works.
- [ ] Verify variant prices/SKUs in the Medusa admin.

Made with [Cursor](https://cursor.com)