### PR TITLE
refactor: use REDIS_URL instead of Upstash REST for cache invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The headless CMS powering [itsmillertime.dev](https://www.itsmillertime.dev), bu
 - **EXIF Extraction** -- background job queue that parses EXIF data from uploaded images using ExifReader
 - **BlurHash Generation** -- generates placeholder blurhash strings for images
 - **Word Count** -- automatic word count tracking on posts
-- **Article cache sync** -- on publish, writes the full article to Upstash at `payload:article:{id}` for the www frontend
+- **Article cache sync** -- on publish/unpublish/delete, invalidates `payload:article:{id}` in Redis so the www frontend repopulates from the CMS
 - **Layout cache sync** -- on save, writes `site-meta` and `site-navigation` globals to `payload:layout:site-meta` and `payload:layout:site-navigation`
 - **Slug Field** -- auto-generated URL slugs from titles
 - **Health Endpoint** -- `GET /api/health` returns service and database status
@@ -82,12 +82,8 @@ DATABASE_URI=postgresql://user:password@localhost:5432/payload
 PAYLOAD_SECRET=your-secret-here
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 
-# Redis
+# Redis (Payload KV + www frontend cache invalidation)
 REDIS_URL=redis://localhost:6379
-
-# Upstash (shared with www — article cache invalidation on publish)
-UPSTASH_REDIS_REST_URL=
-UPSTASH_REDIS_REST_TOKEN=
 
 # Cloudflare R2
 CLOUDFLARE_BUCKET=your-bucket

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@react-email/components": "1.0.12",
     "@react-email/render": "2.0.8",
     "@sentry/nextjs": "10.57.0",
-    "@upstash/redis": "^1.38.0",
+    "ioredis": "^5.4.1",
     "@veiag/payload-cmdk": "^1.1.0",
     "better-auth": "^1.6.17",
     "blurhash": "^2.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       '@sentry/nextjs':
         specifier: 10.57.0
         version: 10.57.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4))(react@19.2.7)(webpack@5.99.9(esbuild@0.25.12))
-      '@upstash/redis':
-        specifier: ^1.38.0
-        version: 1.38.0
       '@veiag/payload-cmdk':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(payload@3.85.1(graphql@16.11.0)(typescript@5.8.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -98,6 +95,9 @@ importers:
       fast-xml-parser:
         specifier: ^5.8.0
         version: 5.8.0
+      ioredis:
+        specifier: ^5.4.1
+        version: 5.10.0
       lucide-react:
         specifier: 0.556.0
         version: 0.556.0(react@19.2.7)
@@ -9668,7 +9668,7 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       '@types/json-schema': 7.0.15
       json-schema-to-zod: 2.6.1
-      mcp-handler: 1.0.7(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4))
+      mcp-handler: 1.0.7(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4))
       payload: 3.85.1(graphql@16.11.0)(typescript@5.8.3)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -11344,6 +11344,7 @@ snapshots:
   '@upstash/redis@1.38.0':
     dependencies:
       uncrypto: 0.1.3
+    optional: true
 
   '@veiag/payload-cmdk@1.1.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(payload@3.85.1(graphql@16.11.0)(typescript@5.8.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -13442,7 +13443,7 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcp-handler@1.0.7(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4)):
+  mcp-handler@1.0.7(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4)):
     dependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       chalk: 5.6.2
@@ -15129,7 +15130,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  uncrypto@0.1.3: {}
+  uncrypto@0.1.3:
+    optional: true
 
   undici-types@7.24.6: {}
 

--- a/src/collections/Posts/Posts/hooks/syncArticleCache.ts
+++ b/src/collections/Posts/Posts/hooks/syncArticleCache.ts
@@ -2,7 +2,7 @@ import { cacheDel, cacheKeys } from '@/lib/cache';
 import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload';
 
 /**
- * Invalidate the Upstash article cache on publish/unpublish/delete so the next
+ * Invalidate the article cache on publish/unpublish/delete so the next
  * www request misses and repopulates fresh from the CMS.
  */
 export const syncArticleCache: CollectionAfterChangeHook = async ({ doc, previousDoc }) => {

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,4 +1,4 @@
-import { Redis } from '@upstash/redis';
+import { Redis } from 'ioredis';
 
 /** Single source of truth for the keys the www frontend reads. */
 export const cacheKeys = {
@@ -10,13 +10,12 @@ export const cacheKeys = {
 let redis: Redis | null = null;
 
 function getRedis(): Redis | null {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) {
-    console.warn('[cache] Upstash not configured; skipping cache invalidation');
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    console.warn('[cache] REDIS_URL not configured; skipping cache invalidation');
     return null;
   }
-  if (!redis) redis = new Redis({ url, token });
+  if (!redis) redis = new Redis(url);
   return redis;
 }
 


### PR DESCRIPTION
Align frontend cache invalidation with the existing Payload KV Redis setup now that Upstash has been replaced by self-hosted Redis.