### PR TITLE
Fix article title typing and bidirectional model/gallery linking

### DIFF
--- a/src/collections/Gallery/Album/index.ts
+++ b/src/collections/Gallery/Album/index.ts
@@ -193,6 +193,17 @@ export const GalleryAlbums: CollectionConfig<'gallery-albums'> = {
       ],
     },
     {
+      name: 'relatedPosts',
+      type: 'join',
+      collection: 'posts',
+      on: 'relatedAlbums',
+      label: 'Related Articles',
+      admin: {
+        description: 'Articles that link to this photo gallery.',
+        allowCreate: false,
+      },
+    },
+    {
       type: 'tabs',
       tabs: [
         {

--- a/src/collections/Models/Models/hooks/syncRelatedPosts.ts
+++ b/src/collections/Models/Models/hooks/syncRelatedPosts.ts
@@ -1,0 +1,145 @@
+import { normalizeRelationIds } from '@/utilities/normalizeRelationIds'
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
+
+type RelationSyncContext = {
+  skipRelationSync?: boolean
+}
+
+const idsEqual = (a: number[], b: number[]) => {
+  if (a.length !== b.length) return false
+  const sortedA = [...a].sort((x, y) => x - y)
+  const sortedB = [...b].sort((x, y) => x - y)
+  return sortedA.every((id, index) => id === sortedB[index])
+}
+
+/**
+ * Keep Posts.relatedModels in sync when a model's relatedPosts change,
+ * so editors can link from either direction.
+ */
+export const syncRelatedPostsOnModelChange: CollectionAfterChangeHook = async ({
+  doc,
+  previousDoc,
+  req,
+  context,
+}) => {
+  const syncContext = context as RelationSyncContext
+  if (syncContext?.skipRelationSync || doc?.id == null) return doc
+
+  const modelId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
+  if (Number.isNaN(modelId)) return doc
+
+  const nextPostIds = normalizeRelationIds(doc.relatedResources?.relatedPosts)
+  const prevPostIds = normalizeRelationIds(previousDoc?.relatedResources?.relatedPosts)
+
+  if (idsEqual(nextPostIds, prevPostIds)) return doc
+
+  const added = nextPostIds.filter((id) => !prevPostIds.includes(id))
+  const removed = prevPostIds.filter((id) => !nextPostIds.includes(id))
+
+  for (const postId of added) {
+    try {
+      const post = await req.payload.findByID({
+        collection: 'posts',
+        id: postId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentModels = normalizeRelationIds(post.relatedModels)
+      if (currentModels.includes(modelId)) continue
+
+      await req.payload.update({
+        collection: 'posts',
+        id: postId,
+        data: {
+          relatedModels: [...currentModels, modelId],
+        },
+        depth: 0,
+        overrideAccess: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      req.payload.logger.error({
+        err,
+        msg: `Failed to add model ${modelId} to post ${postId} relatedModels`,
+      })
+    }
+  }
+
+  for (const postId of removed) {
+    try {
+      const post = await req.payload.findByID({
+        collection: 'posts',
+        id: postId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentModels = normalizeRelationIds(post.relatedModels)
+      if (!currentModels.includes(modelId)) continue
+
+      await req.payload.update({
+        collection: 'posts',
+        id: postId,
+        data: {
+          relatedModels: currentModels.filter((id) => id !== modelId),
+        },
+        depth: 0,
+        overrideAccess: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      req.payload.logger.error({
+        err,
+        msg: `Failed to remove model ${modelId} from post ${postId} relatedModels`,
+      })
+    }
+  }
+
+  return doc
+}
+
+export const removeModelFromRelatedPostsOnDelete: CollectionAfterDeleteHook = async ({
+  doc,
+  req,
+}) => {
+  if (doc?.id == null) return doc
+
+  const modelId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
+  if (Number.isNaN(modelId)) return doc
+
+  const postIds = normalizeRelationIds(doc.relatedResources?.relatedPosts)
+  if (postIds.length === 0) return doc
+
+  for (const postId of postIds) {
+    try {
+      const post = await req.payload.findByID({
+        collection: 'posts',
+        id: postId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentModels = normalizeRelationIds(post.relatedModels)
+      if (!currentModels.includes(modelId)) continue
+
+      await req.payload.update({
+        collection: 'posts',
+        id: postId,
+        data: {
+          relatedModels: currentModels.filter((id) => id !== modelId),
+        },
+        depth: 0,
+        overrideAccess: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      req.payload.logger.error({
+        err,
+        msg: `Failed to remove deleted model ${modelId} from post ${postId} relatedModels`,
+      })
+    }
+  }
+
+  return doc
+}

--- a/src/collections/Models/Models/index.ts
+++ b/src/collections/Models/Models/index.ts
@@ -13,6 +13,10 @@ import {
 } from '@payloadcms/plugin-seo/fields';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { CollectionConfig } from 'payload';
+import {
+  removeModelFromRelatedPostsOnDelete,
+  syncRelatedPostsOnModelChange,
+} from './hooks/syncRelatedPosts';
 
 export const Models: CollectionConfig<'models'> = {
   slug: 'models',
@@ -62,6 +66,8 @@ export const Models: CollectionConfig<'models'> = {
         }
       },
     ],
+    afterChange: [syncRelatedPostsOnModelChange],
+    afterDelete: [removeModelFromRelatedPostsOnDelete],
   },
   fields: [
     {
@@ -190,6 +196,9 @@ export const Models: CollectionConfig<'models'> = {
           type: 'relationship',
           hasMany: true,
           relationTo: 'posts',
+          admin: {
+            description: 'Link articles from this model. Also editable from the article.',
+          },
         },
         {
           name: 'relatedModels',

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -173,7 +173,8 @@ export const Pages: CollectionConfig<'pages'> = {
   versions: {
     drafts: {
       autosave: {
-        interval: 100,
+        // Keep in sync with Posts — 100ms races keystrokes and overwrites typed text.
+        interval: 2000,
       },
       schedulePublish: true,
     },

--- a/src/collections/Posts/Posts/hooks/syncRelatedModels.ts
+++ b/src/collections/Posts/Posts/hooks/syncRelatedModels.ts
@@ -1,0 +1,154 @@
+import { normalizeRelationIds } from '@/utilities/normalizeRelationIds'
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
+
+type RelationSyncContext = {
+  skipRelationSync?: boolean
+}
+
+const idsEqual = (a: number[], b: number[]) => {
+  if (a.length !== b.length) return false
+  const sortedA = [...a].sort((x, y) => x - y)
+  const sortedB = [...b].sort((x, y) => x - y)
+  return sortedA.every((id, index) => id === sortedB[index])
+}
+
+/**
+ * Keep Models.relatedResources.relatedPosts in sync when an article's relatedModels change,
+ * so editors can link from either direction without duplicate sources of truth drifting.
+ */
+export const syncRelatedModelsOnPostChange: CollectionAfterChangeHook = async ({
+  doc,
+  previousDoc,
+  req,
+  context,
+}) => {
+  const syncContext = context as RelationSyncContext
+  if (syncContext?.skipRelationSync || doc?.id == null) return doc
+
+  const postId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
+  if (Number.isNaN(postId)) return doc
+
+  const nextModelIds = normalizeRelationIds(doc.relatedModels)
+  const prevModelIds = normalizeRelationIds(previousDoc?.relatedModels)
+
+  if (idsEqual(nextModelIds, prevModelIds)) return doc
+
+  const added = nextModelIds.filter((id) => !prevModelIds.includes(id))
+  const removed = prevModelIds.filter((id) => !nextModelIds.includes(id))
+
+  for (const modelId of added) {
+    try {
+      const model = await req.payload.findByID({
+        collection: 'models',
+        id: modelId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentPosts = normalizeRelationIds(model.relatedResources?.relatedPosts)
+      if (currentPosts.includes(postId)) continue
+
+      await req.payload.update({
+        collection: 'models',
+        id: modelId,
+        data: {
+          relatedResources: {
+            relatedPosts: [...currentPosts, postId],
+            relatedModels: normalizeRelationIds(model.relatedResources?.relatedModels),
+          },
+        },
+        depth: 0,
+        overrideAccess: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      req.payload.logger.error({
+        err,
+        msg: `Failed to add post ${postId} to model ${modelId} relatedPosts`,
+      })
+    }
+  }
+
+  for (const modelId of removed) {
+    try {
+      const model = await req.payload.findByID({
+        collection: 'models',
+        id: modelId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentPosts = normalizeRelationIds(model.relatedResources?.relatedPosts)
+      if (!currentPosts.includes(postId)) continue
+
+      await req.payload.update({
+        collection: 'models',
+        id: modelId,
+        data: {
+          relatedResources: {
+            relatedPosts: currentPosts.filter((id) => id !== postId),
+            relatedModels: normalizeRelationIds(model.relatedResources?.relatedModels),
+          },
+        },
+        depth: 0,
+        overrideAccess: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      req.payload.logger.error({
+        err,
+        msg: `Failed to remove post ${postId} from model ${modelId} relatedPosts`,
+      })
+    }
+  }
+
+  return doc
+}
+
+export const removePostFromRelatedModelsOnDelete: CollectionAfterDeleteHook = async ({
+  doc,
+  req,
+}) => {
+  if (doc?.id == null) return doc
+
+  const postId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
+  if (Number.isNaN(postId)) return doc
+
+  const modelIds = normalizeRelationIds(doc.relatedModels)
+  if (modelIds.length === 0) return doc
+
+  for (const modelId of modelIds) {
+    try {
+      const model = await req.payload.findByID({
+        collection: 'models',
+        id: modelId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentPosts = normalizeRelationIds(model.relatedResources?.relatedPosts)
+      if (!currentPosts.includes(postId)) continue
+
+      await req.payload.update({
+        collection: 'models',
+        id: modelId,
+        data: {
+          relatedResources: {
+            relatedPosts: currentPosts.filter((id) => id !== postId),
+            relatedModels: normalizeRelationIds(model.relatedResources?.relatedModels),
+          },
+        },
+        depth: 0,
+        overrideAccess: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      req.payload.logger.error({
+        err,
+        msg: `Failed to remove deleted post ${postId} from model ${modelId} relatedPosts`,
+      })
+    }
+  }
+
+  return doc
+}

--- a/src/collections/Posts/Posts/index.ts
+++ b/src/collections/Posts/Posts/index.ts
@@ -14,6 +14,13 @@ import {
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { CollectionConfig } from 'payload';
 import { removeArticleCacheOnDelete, syncArticleCache } from './hooks/syncArticleCache';
+import {
+  removePostFromRelatedModelsOnDelete,
+  syncRelatedModelsOnPostChange,
+} from './hooks/syncRelatedModels';
+
+/** Autosave interval slow enough to avoid racing keystrokes in title/text fields. */
+const AUTOSAVE_INTERVAL_MS = 2000;
 
 export const Posts: CollectionConfig<'posts'> = {
   slug: 'posts',
@@ -131,6 +138,28 @@ export const Posts: CollectionConfig<'posts'> = {
       relationTo: 'posts',
     },
     {
+      name: 'relatedModels',
+      type: 'relationship',
+      label: 'Related Models',
+      admin: {
+        position: 'sidebar',
+        description: 'Link models from this article. Also editable from the model.',
+      },
+      hasMany: true,
+      relationTo: 'models',
+    },
+    {
+      name: 'relatedAlbums',
+      type: 'relationship',
+      label: 'Related Photo Galleries',
+      admin: {
+        position: 'sidebar',
+        description: 'Link photo gallery albums to this article.',
+      },
+      hasMany: true,
+      relationTo: 'gallery-albums',
+    },
+    {
       type: 'tabs',
       tabs: [
         {
@@ -199,14 +228,14 @@ export const Posts: CollectionConfig<'posts'> = {
   versions: {
     drafts: {
       autosave: {
-        interval: 100,
+        interval: AUTOSAVE_INTERVAL_MS,
       },
       schedulePublish: true,
     },
     maxPerDoc: 5,
   },
   hooks: {
-    afterChange: [syncArticleCache],
-    afterDelete: [removeArticleCacheOnDelete],
+    afterChange: [syncArticleCache, syncRelatedModelsOnPostChange],
+    afterDelete: [removeArticleCacheOnDelete, removePostFromRelatedModelsOnDelete],
   },
 };

--- a/src/collections/Projects/Projects/index.ts
+++ b/src/collections/Projects/Projects/index.ts
@@ -266,7 +266,8 @@ export const Projects: CollectionConfig<'projects'> = {
   versions: {
     drafts: {
       autosave: {
-        interval: 100,
+        // Keep in sync with Posts — 100ms races keystrokes and overwrites typed text.
+        interval: 2000,
       },
       schedulePublish: true,
     },

--- a/src/migrations/20260727_article_relations.ts
+++ b/src/migrations/20260727_article_relations.ts
@@ -1,0 +1,94 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * - Add posts ↔ models / gallery-albums relationship columns
+ * - Backfill posts.relatedModels from existing models.relatedResources.relatedPosts
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "posts_rels" ADD COLUMN IF NOT EXISTS "models_id" integer;
+    ALTER TABLE "posts_rels" ADD COLUMN IF NOT EXISTS "gallery_albums_id" integer;
+
+    DO $$ BEGIN
+      ALTER TABLE "posts_rels"
+        ADD CONSTRAINT "posts_rels_models_fk"
+        FOREIGN KEY ("models_id") REFERENCES "public"."models"("id")
+        ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "posts_rels"
+        ADD CONSTRAINT "posts_rels_gallery_albums_fk"
+        FOREIGN KEY ("gallery_albums_id") REFERENCES "public"."gallery_albums"("id")
+        ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "posts_rels_models_id_idx" ON "posts_rels" USING btree ("models_id");
+    CREATE INDEX IF NOT EXISTS "posts_rels_gallery_albums_id_idx" ON "posts_rels" USING btree ("gallery_albums_id");
+
+    ALTER TABLE "_posts_v_rels" ADD COLUMN IF NOT EXISTS "models_id" integer;
+    ALTER TABLE "_posts_v_rels" ADD COLUMN IF NOT EXISTS "gallery_albums_id" integer;
+
+    DO $$ BEGIN
+      ALTER TABLE "_posts_v_rels"
+        ADD CONSTRAINT "_posts_v_rels_models_fk"
+        FOREIGN KEY ("models_id") REFERENCES "public"."models"("id")
+        ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "_posts_v_rels"
+        ADD CONSTRAINT "_posts_v_rels_gallery_albums_fk"
+        FOREIGN KEY ("gallery_albums_id") REFERENCES "public"."gallery_albums"("id")
+        ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "_posts_v_rels_models_id_idx" ON "_posts_v_rels" USING btree ("models_id");
+    CREATE INDEX IF NOT EXISTS "_posts_v_rels_gallery_albums_id_idx" ON "_posts_v_rels" USING btree ("gallery_albums_id");
+
+    -- Mirror existing model → article links onto articles as relatedModels
+    INSERT INTO "posts_rels" ("order", "parent_id", "path", "models_id")
+    SELECT
+      mr."order",
+      mr."posts_id",
+      'relatedModels',
+      mr."parent_id"
+    FROM "models_rels" mr
+    WHERE mr."path" = 'relatedResources.relatedPosts'
+      AND mr."posts_id" IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "posts_rels" pr
+        WHERE pr."parent_id" = mr."posts_id"
+          AND pr."path" = 'relatedModels'
+          AND pr."models_id" = mr."parent_id"
+      );
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DELETE FROM "posts_rels" WHERE "path" = 'relatedModels';
+    DELETE FROM "posts_rels" WHERE "path" = 'relatedAlbums';
+    DELETE FROM "_posts_v_rels" WHERE "path" = 'relatedModels';
+    DELETE FROM "_posts_v_rels" WHERE "path" = 'relatedAlbums';
+
+    ALTER TABLE "posts_rels" DROP CONSTRAINT IF EXISTS "posts_rels_models_fk";
+    ALTER TABLE "posts_rels" DROP CONSTRAINT IF EXISTS "posts_rels_gallery_albums_fk";
+    DROP INDEX IF EXISTS "posts_rels_models_id_idx";
+    DROP INDEX IF EXISTS "posts_rels_gallery_albums_id_idx";
+    ALTER TABLE "posts_rels" DROP COLUMN IF EXISTS "models_id";
+    ALTER TABLE "posts_rels" DROP COLUMN IF EXISTS "gallery_albums_id";
+
+    ALTER TABLE "_posts_v_rels" DROP CONSTRAINT IF EXISTS "_posts_v_rels_models_fk";
+    ALTER TABLE "_posts_v_rels" DROP CONSTRAINT IF EXISTS "_posts_v_rels_gallery_albums_fk";
+    DROP INDEX IF EXISTS "_posts_v_rels_models_id_idx";
+    DROP INDEX IF EXISTS "_posts_v_rels_gallery_albums_id_idx";
+    ALTER TABLE "_posts_v_rels" DROP COLUMN IF EXISTS "models_id";
+    ALTER TABLE "_posts_v_rels" DROP COLUMN IF EXISTS "gallery_albums_id";
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,9 +1,15 @@
 import * as migration_20260612_072836_better_auth_1_6 from './20260612_072836_better_auth_1_6';
+import * as migration_20260727_article_relations from './20260727_article_relations';
 
 export const migrations = [
   {
     up: migration_20260612_072836_better_auth_1_6.up,
     down: migration_20260612_072836_better_auth_1_6.down,
-    name: '20260612_072836_better_auth_1_6'
+    name: '20260612_072836_better_auth_1_6',
+  },
+  {
+    up: migration_20260727_article_relations.up,
+    down: migration_20260727_article_relations.down,
+    name: '20260727_article_relations',
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -112,6 +112,7 @@ export interface Config {
       relatedPosts: 'posts';
     };
     'gallery-albums': {
+      relatedPosts: 'posts';
       images: 'gallery-images';
     };
     kits: {
@@ -291,6 +292,14 @@ export interface GalleryAlbum {
     shares?: number | null;
     totalImages?: number | null;
   };
+  /**
+   * Articles that link to this photo gallery.
+   */
+  relatedPosts?: {
+    docs?: (number | Post)[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
   title: string;
   content?: {
     root: {
@@ -403,6 +412,357 @@ export interface User {
   updatedAt: string;
   createdAt: string;
   collection: 'users';
+}
+/**
+ * Blog Posts
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts".
+ */
+export interface Post {
+  id: number;
+  originalPublicationDate?: string | null;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  word_count?: number | null;
+  category?: (number | null) | PostsCategory;
+  tags?: (number | PostsTag)[] | null;
+  relatedPosts?: (number | Post)[] | null;
+  /**
+   * Link models from this article. Also editable from the model.
+   */
+  relatedModels?: (number | Model)[] | null;
+  /**
+   * Link photo gallery albums to this article.
+   */
+  relatedAlbums?: (number | GalleryAlbum)[] | null;
+  title: string;
+  subheading?: string | null;
+  featuredImage?: (number | null) | Media;
+  content?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  meta?: {
+    title?: string | null;
+    description?: string | null;
+    image?: (number | null) | Media;
+  };
+  updatedAt: string;
+  createdAt: string;
+  deletedAt?: string | null;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * Blog categories.  Used for general classification of blog posts.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-categories".
+ */
+export interface PostsCategory {
+  id: number;
+  title: string;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Blog tags.  Used for more focused classification of blog posts.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-tags".
+ */
+export interface PostsTag {
+  id: number;
+  title: string;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * A built model, not to be confused with a kit
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "models".
+ */
+export interface Model {
+  id: number;
+  title: string;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  /**
+   * Select a Clockify Project from your workspace
+   */
+  clockify_project?: string | null;
+  model_meta: {
+    featuredImage: number | Media;
+    status: 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED';
+    completionDate?: string | null;
+    kit: number | Kit;
+    tags?: (number | ModelsTag)[] | null;
+    videos?:
+      | {
+          title: string;
+          url?: string | null;
+          id?: string | null;
+        }[]
+      | null;
+  };
+  relatedResources?: {
+    /**
+     * Link articles from this model. Also editable from the article.
+     */
+    relatedPosts?: (number | Post)[] | null;
+    relatedModels?: (number | Model)[] | null;
+  };
+  buildLog?:
+    | {
+        title: string;
+        content?: {
+          root: {
+            type: string;
+            children: {
+              type: any;
+              version: number;
+              [k: string]: unknown;
+            }[];
+            direction: ('ltr' | 'rtl') | null;
+            format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+            indent: number;
+            version: number;
+          };
+          [k: string]: unknown;
+        } | null;
+        id?: string | null;
+      }[]
+    | null;
+  image?: (number | Media)[] | null;
+  meta?: {
+    title?: string | null;
+    description?: string | null;
+    image?: (number | null) | Media;
+  };
+  updatedAt: string;
+  createdAt: string;
+  deletedAt?: string | null;
+}
+/**
+ * Media Items, images and otherwise
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media".
+ */
+export interface Media {
+  id: number;
+  exif?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  blurhash?: string | null;
+  alt: string;
+  caption?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  relatedPosts?: {
+    docs?: {
+      relationTo?: 'posts';
+      value: number | Post;
+    }[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
+  folder?: (number | null) | FolderInterface;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+  sizes?: {
+    thumbnail?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+    square?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+    small?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+    medium?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+    large?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+    xlarge?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+    og?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+  };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-folders".
+ */
+export interface FolderInterface {
+  id: number;
+  name: string;
+  folder?: (number | null) | FolderInterface;
+  documentsAndFolders?: {
+    docs?: (
+      | {
+          relationTo?: 'payload-folders';
+          value: number | FolderInterface;
+        }
+      | {
+          relationTo?: 'media';
+          value: number | Media;
+        }
+    )[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
+  folderType?: 'media'[] | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Model Kits
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "kits".
+ */
+export interface Kit {
+  id: number;
+  full_title: string;
+  title: string;
+  kit_number: string;
+  year_released: number;
+  scalemates?: string | null;
+  models?: {
+    docs?: (number | Model)[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
+  manufacturer: number | Manufacturer;
+  scale: number | Scale;
+  boxart?: (number | null) | Media;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Model kit manufacturers
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "manufacturers".
+ */
+export interface Manufacturer {
+  id: number;
+  title: string;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Model kit scales
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "scales".
+ */
+export interface Scale {
+  id: number;
+  title: string;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Models tags.  Used for more focused classification of models.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "models-tags".
+ */
+export interface ModelsTag {
+  id: number;
+  title: string;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * Image
@@ -537,216 +897,6 @@ export interface GalleryImage {
   };
 }
 /**
- * Media Items, images and otherwise
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "media".
- */
-export interface Media {
-  id: number;
-  exif?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  blurhash?: string | null;
-  alt: string;
-  caption?: {
-    root: {
-      type: string;
-      children: {
-        type: any;
-        version: number;
-        [k: string]: unknown;
-      }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-      indent: number;
-      version: number;
-    };
-    [k: string]: unknown;
-  } | null;
-  relatedPosts?: {
-    docs?: {
-      relationTo?: 'posts';
-      value: number | Post;
-    }[];
-    hasNextPage?: boolean;
-    totalDocs?: number;
-  };
-  folder?: (number | null) | FolderInterface;
-  updatedAt: string;
-  createdAt: string;
-  url?: string | null;
-  thumbnailURL?: string | null;
-  filename?: string | null;
-  mimeType?: string | null;
-  filesize?: number | null;
-  width?: number | null;
-  height?: number | null;
-  focalX?: number | null;
-  focalY?: number | null;
-  sizes?: {
-    thumbnail?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-    square?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-    small?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-    medium?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-    large?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-    xlarge?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-    og?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-  };
-}
-/**
- * Blog Posts
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "posts".
- */
-export interface Post {
-  id: number;
-  originalPublicationDate?: string | null;
-  slug?: string | null;
-  slugLock?: boolean | null;
-  word_count?: number | null;
-  category?: (number | null) | PostsCategory;
-  tags?: (number | PostsTag)[] | null;
-  relatedPosts?: (number | Post)[] | null;
-  title: string;
-  subheading?: string | null;
-  featuredImage?: (number | null) | Media;
-  content?: {
-    root: {
-      type: string;
-      children: {
-        type: any;
-        version: number;
-        [k: string]: unknown;
-      }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-      indent: number;
-      version: number;
-    };
-    [k: string]: unknown;
-  } | null;
-  meta?: {
-    title?: string | null;
-    description?: string | null;
-    image?: (number | null) | Media;
-  };
-  updatedAt: string;
-  createdAt: string;
-  deletedAt?: string | null;
-  _status?: ('draft' | 'published') | null;
-}
-/**
- * Blog categories.  Used for general classification of blog posts.
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "posts-categories".
- */
-export interface PostsCategory {
-  id: number;
-  title: string;
-  slug?: string | null;
-  slugLock?: boolean | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * Blog tags.  Used for more focused classification of blog posts.
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "posts-tags".
- */
-export interface PostsTag {
-  id: number;
-  title: string;
-  slug?: string | null;
-  slugLock?: boolean | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "payload-folders".
- */
-export interface FolderInterface {
-  id: number;
-  name: string;
-  folder?: (number | null) | FolderInterface;
-  documentsAndFolders?: {
-    docs?: (
-      | {
-          relationTo?: 'payload-folders';
-          value: number | FolderInterface;
-        }
-      | {
-          relationTo?: 'media';
-          value: number | Media;
-        }
-    )[];
-    hasNextPage?: boolean;
-    totalDocs?: number;
-  };
-  folderType?: 'media'[] | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
  * Singular dynamic page of the front end
  *
  * This interface was referenced by `Config`'s JSON-Schema
@@ -827,136 +977,6 @@ export interface Garden {
   updatedAt: string;
   createdAt: string;
   deletedAt?: string | null;
-}
-/**
- * Model Kits
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "kits".
- */
-export interface Kit {
-  id: number;
-  full_title: string;
-  title: string;
-  kit_number: string;
-  year_released: number;
-  scalemates?: string | null;
-  models?: {
-    docs?: (number | Model)[];
-    hasNextPage?: boolean;
-    totalDocs?: number;
-  };
-  manufacturer: number | Manufacturer;
-  scale: number | Scale;
-  boxart?: (number | null) | Media;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * A built model, not to be confused with a kit
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "models".
- */
-export interface Model {
-  id: number;
-  title: string;
-  slug?: string | null;
-  slugLock?: boolean | null;
-  /**
-   * Select a Clockify Project from your workspace
-   */
-  clockify_project?: string | null;
-  model_meta: {
-    featuredImage: number | Media;
-    status: 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED';
-    completionDate?: string | null;
-    kit: number | Kit;
-    tags?: (number | ModelsTag)[] | null;
-    videos?:
-      | {
-          title: string;
-          url?: string | null;
-          id?: string | null;
-        }[]
-      | null;
-  };
-  relatedResources?: {
-    relatedPosts?: (number | Post)[] | null;
-    relatedModels?: (number | Model)[] | null;
-  };
-  buildLog?:
-    | {
-        title: string;
-        content?: {
-          root: {
-            type: string;
-            children: {
-              type: any;
-              version: number;
-              [k: string]: unknown;
-            }[];
-            direction: ('ltr' | 'rtl') | null;
-            format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-            indent: number;
-            version: number;
-          };
-          [k: string]: unknown;
-        } | null;
-        id?: string | null;
-      }[]
-    | null;
-  image?: (number | Media)[] | null;
-  meta?: {
-    title?: string | null;
-    description?: string | null;
-    image?: (number | null) | Media;
-  };
-  updatedAt: string;
-  createdAt: string;
-  deletedAt?: string | null;
-}
-/**
- * Models tags.  Used for more focused classification of models.
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "models-tags".
- */
-export interface ModelsTag {
-  id: number;
-  title: string;
-  slug?: string | null;
-  slugLock?: boolean | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * Model kit manufacturers
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "manufacturers".
- */
-export interface Manufacturer {
-  id: number;
-  title: string;
-  slug?: string | null;
-  slugLock?: boolean | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * Model kit scales
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "scales".
- */
-export interface Scale {
-  id: number;
-  title: string;
-  slug?: string | null;
-  slugLock?: boolean | null;
-  updatedAt: string;
-  createdAt: string;
 }
 /**
  * Coding projects and portfolio items
@@ -2064,6 +2084,8 @@ export interface PostsSelect<T extends boolean = true> {
   category?: T;
   tags?: T;
   relatedPosts?: T;
+  relatedModels?: T;
+  relatedAlbums?: T;
   title?: T;
   subheading?: T;
   featuredImage?: T;
@@ -2158,6 +2180,7 @@ export interface GalleryAlbumsSelect<T extends boolean = true> {
         shares?: T;
         totalImages?: T;
       };
+  relatedPosts?: T;
   title?: T;
   content?: T;
   images?: T;

--- a/src/utilities/normalizeRelationIds.ts
+++ b/src/utilities/normalizeRelationIds.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalize Payload relationship values (ids or populated docs) to a unique id list.
+ */
+export const normalizeRelationIds = (value: unknown): number[] => {
+  if (!Array.isArray(value)) return []
+
+  const ids = value
+    .map((item) => {
+      if (typeof item === 'number') return item
+      if (typeof item === 'string' && item !== '' && !Number.isNaN(Number(item))) {
+        return Number(item)
+      }
+      if (item && typeof item === 'object' && 'id' in item) {
+        const id = (item as { id: unknown }).id
+        if (typeof id === 'number') return id
+        if (typeof id === 'string' && id !== '' && !Number.isNaN(Number(id))) {
+          return Number(id)
+        }
+      }
+      return null
+    })
+    .filter((id): id is number => id != null)
+
+  return [...new Set(ids)]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes three related CMS editor issues:

1. **Title input going crazy** — Draft autosave was set to `100ms`, which races keystrokes against save-response form merges (letters disappear / overwrite). Raised to `2000ms` on Articles, Pages, and Projects.

2. **Model ↔ Article linking from either side** — Articles now have a `relatedModels` field. Linking from a model or from an article stays in sync via afterChange hooks. Existing model→article links are backfilled by migration.

3. **Article → photo gallery linking** — Articles now have a `relatedAlbums` field (gallery albums). Albums show a read-only join of articles that link to them.

## Deploy notes

Run Payload migrations after deploy so the new `posts_rels` columns exist and existing model→post links are copied onto articles:

```bash
pnpm payload migrate
```

## Test plan

- [ ] Edit an article title quickly — characters should stick without disappearing/overwriting
- [ ] From a model, relate an article; open that article and confirm the model appears under Related Models
- [ ] From an article, relate a model; open that model and confirm the article appears under Related Posts
- [ ] From an article, relate a photo gallery album; confirm it saves and shows on the album’s Related Articles join
- [ ] Run `pnpm payload migrate` against a DB with existing model→post links and confirm articles pick them up

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2217376-2fd5-45cf-840a-5220df84d4eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2217376-2fd5-45cf-840a-5220df84d4eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

