### PR TITLE
Restore editable two-way article–model relationships.

### DIFF
--- a/src/collections/Models/Models/hooks/syncRelatedPosts.ts
+++ b/src/collections/Models/Models/hooks/syncRelatedPosts.ts
@@ -1,0 +1,145 @@
+import {
+  idsEqual,
+  normalizeRelationIds,
+  shouldSkipRelationSync,
+} from '@/utilities/relationSync'
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
+
+/**
+ * Keep Posts.relatedModels in sync when a model's relatedPosts change.
+ *
+ * Nested post updates omit `req` (separate from the model transaction) and use
+ * overrideLock so draft/autosave locks on articles don't block the model save.
+ */
+export const syncRelatedPostsOnModelChange: CollectionAfterChangeHook = async ({
+  doc,
+  previousDoc,
+  req,
+  context,
+}) => {
+  if (shouldSkipRelationSync(req, context) || doc?.id == null) return doc
+
+  const modelId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
+  if (Number.isNaN(modelId)) return doc
+
+  const nextPostIds = normalizeRelationIds(doc.relatedPosts)
+  const prevPostIds = normalizeRelationIds(previousDoc?.relatedPosts)
+
+  if (idsEqual(nextPostIds, prevPostIds)) return doc
+
+  const added = nextPostIds.filter((id) => !prevPostIds.includes(id))
+  const removed = prevPostIds.filter((id) => !nextPostIds.includes(id))
+  const { payload } = req
+
+  for (const postId of added) {
+    try {
+      const post = await payload.findByID({
+        collection: 'posts',
+        id: postId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentModels = normalizeRelationIds(post.relatedModels)
+      if (currentModels.includes(modelId)) continue
+
+      await payload.update({
+        collection: 'posts',
+        id: postId,
+        data: {
+          relatedModels: [...currentModels, modelId],
+        },
+        depth: 0,
+        overrideAccess: true,
+        overrideLock: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      payload.logger.error({
+        err,
+        msg: `Failed to add model ${modelId} to post ${postId} relatedModels`,
+      })
+    }
+  }
+
+  for (const postId of removed) {
+    try {
+      const post = await payload.findByID({
+        collection: 'posts',
+        id: postId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentModels = normalizeRelationIds(post.relatedModels)
+      if (!currentModels.includes(modelId)) continue
+
+      await payload.update({
+        collection: 'posts',
+        id: postId,
+        data: {
+          relatedModels: currentModels.filter((id) => id !== modelId),
+        },
+        depth: 0,
+        overrideAccess: true,
+        overrideLock: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      payload.logger.error({
+        err,
+        msg: `Failed to remove model ${modelId} from post ${postId} relatedModels`,
+      })
+    }
+  }
+
+  return doc
+}
+
+export const removeModelFromRelatedPostsOnDelete: CollectionAfterDeleteHook = async ({
+  doc,
+  req,
+}) => {
+  if (doc?.id == null) return doc
+
+  const modelId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
+  if (Number.isNaN(modelId)) return doc
+
+  const postIds = normalizeRelationIds(doc.relatedPosts)
+  if (postIds.length === 0) return doc
+
+  const { payload } = req
+
+  for (const postId of postIds) {
+    try {
+      const post = await payload.findByID({
+        collection: 'posts',
+        id: postId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentModels = normalizeRelationIds(post.relatedModels)
+      if (!currentModels.includes(modelId)) continue
+
+      await payload.update({
+        collection: 'posts',
+        id: postId,
+        data: {
+          relatedModels: currentModels.filter((id) => id !== modelId),
+        },
+        depth: 0,
+        overrideAccess: true,
+        overrideLock: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      payload.logger.error({
+        err,
+        msg: `Failed to remove deleted model ${modelId} from post ${postId} relatedModels`,
+      })
+    }
+  }
+
+  return doc
+}

--- a/src/collections/Models/Models/index.ts
+++ b/src/collections/Models/Models/index.ts
@@ -13,6 +13,10 @@ import {
 } from '@payloadcms/plugin-seo/fields';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { CollectionConfig } from 'payload';
+import {
+  removeModelFromRelatedPostsOnDelete,
+  syncRelatedPostsOnModelChange,
+} from './hooks/syncRelatedPosts';
 
 export const Models: CollectionConfig<'models'> = {
   slug: 'models',
@@ -62,6 +66,8 @@ export const Models: CollectionConfig<'models'> = {
         }
       },
     ],
+    afterChange: [syncRelatedPostsOnModelChange],
+    afterDelete: [removeModelFromRelatedPostsOnDelete],
   },
   fields: [
     {
@@ -179,15 +185,13 @@ export const Models: CollectionConfig<'models'> = {
     },
     {
       name: 'relatedPosts',
-      type: 'join',
-      collection: 'posts',
-      on: 'relatedModels',
+      type: 'relationship',
+      hasMany: true,
+      relationTo: 'posts',
       label: 'Related Articles',
       admin: {
         position: 'sidebar',
-        description:
-          'Articles that link to this model. Add or remove links from the article sidebar.',
-        allowCreate: false,
+        description: 'Link articles from this model. Also editable from the article.',
       },
     },
     {

--- a/src/collections/Posts/Posts/hooks/syncRelatedModels.ts
+++ b/src/collections/Posts/Posts/hooks/syncRelatedModels.ts
@@ -1,0 +1,142 @@
+import {
+  idsEqual,
+  normalizeRelationIds,
+  shouldSkipRelationSync,
+} from '@/utilities/relationSync'
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
+
+/**
+ * Keep Models.relatedPosts in sync when an article's relatedModels change.
+ *
+ * Nested updates intentionally omit `req` so they run outside the parent
+ * transaction (avoids lock contention with draft/versioned post saves).
+ */
+export const syncRelatedModelsOnPostChange: CollectionAfterChangeHook = async ({
+  doc,
+  previousDoc,
+  req,
+  context,
+}) => {
+  if (shouldSkipRelationSync(req, context) || doc?.id == null) return doc
+
+  const postId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
+  if (Number.isNaN(postId)) return doc
+
+  const nextModelIds = normalizeRelationIds(doc.relatedModels)
+  const prevModelIds = normalizeRelationIds(previousDoc?.relatedModels)
+
+  if (idsEqual(nextModelIds, prevModelIds)) return doc
+
+  const added = nextModelIds.filter((id) => !prevModelIds.includes(id))
+  const removed = prevModelIds.filter((id) => !nextModelIds.includes(id))
+  const { payload } = req
+
+  for (const modelId of added) {
+    try {
+      const model = await payload.findByID({
+        collection: 'models',
+        id: modelId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentPosts = normalizeRelationIds(model.relatedPosts)
+      if (currentPosts.includes(postId)) continue
+
+      await payload.update({
+        collection: 'models',
+        id: modelId,
+        data: {
+          relatedPosts: [...currentPosts, postId],
+        },
+        depth: 0,
+        overrideAccess: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      payload.logger.error({
+        err,
+        msg: `Failed to add post ${postId} to model ${modelId} relatedPosts`,
+      })
+    }
+  }
+
+  for (const modelId of removed) {
+    try {
+      const model = await payload.findByID({
+        collection: 'models',
+        id: modelId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentPosts = normalizeRelationIds(model.relatedPosts)
+      if (!currentPosts.includes(postId)) continue
+
+      await payload.update({
+        collection: 'models',
+        id: modelId,
+        data: {
+          relatedPosts: currentPosts.filter((id) => id !== postId),
+        },
+        depth: 0,
+        overrideAccess: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      payload.logger.error({
+        err,
+        msg: `Failed to remove post ${postId} from model ${modelId} relatedPosts`,
+      })
+    }
+  }
+
+  return doc
+}
+
+export const removePostFromRelatedModelsOnDelete: CollectionAfterDeleteHook = async ({
+  doc,
+  req,
+}) => {
+  if (doc?.id == null) return doc
+
+  const postId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
+  if (Number.isNaN(postId)) return doc
+
+  const modelIds = normalizeRelationIds(doc.relatedModels)
+  if (modelIds.length === 0) return doc
+
+  const { payload } = req
+
+  for (const modelId of modelIds) {
+    try {
+      const model = await payload.findByID({
+        collection: 'models',
+        id: modelId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      const currentPosts = normalizeRelationIds(model.relatedPosts)
+      if (!currentPosts.includes(postId)) continue
+
+      await payload.update({
+        collection: 'models',
+        id: modelId,
+        data: {
+          relatedPosts: currentPosts.filter((id) => id !== postId),
+        },
+        depth: 0,
+        overrideAccess: true,
+        context: { skipRelationSync: true },
+      })
+    } catch (err) {
+      payload.logger.error({
+        err,
+        msg: `Failed to remove deleted post ${postId} from model ${modelId} relatedPosts`,
+      })
+    }
+  }
+
+  return doc
+}

--- a/src/collections/Posts/Posts/index.ts
+++ b/src/collections/Posts/Posts/index.ts
@@ -13,6 +13,10 @@ import {
 } from '@payloadcms/plugin-seo/fields';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { CollectionConfig } from 'payload';
+import {
+  removePostFromRelatedModelsOnDelete,
+  syncRelatedModelsOnPostChange,
+} from './hooks/syncRelatedModels';
 
 /** Autosave interval slow enough to avoid racing keystrokes in title/text fields. */
 const AUTOSAVE_INTERVAL_MS = 2000;
@@ -138,7 +142,7 @@ export const Posts: CollectionConfig<'posts'> = {
       label: 'Related Models',
       admin: {
         position: 'sidebar',
-        description: 'Link models to this article. Shown as Related Articles on the model.',
+        description: 'Link models from this article. Also editable from the model.',
       },
       hasMany: true,
       relationTo: 'models',
@@ -149,7 +153,8 @@ export const Posts: CollectionConfig<'posts'> = {
       label: 'Related Photo Galleries',
       admin: {
         position: 'sidebar',
-        description: 'Link photo gallery albums to this article. Shown on the album as Related Articles.',
+        description:
+          'Link photo gallery albums to this article. Shown on the album as Related Articles.',
       },
       hasMany: true,
       relationTo: 'gallery-albums',
@@ -228,5 +233,9 @@ export const Posts: CollectionConfig<'posts'> = {
       schedulePublish: true,
     },
     maxPerDoc: 5,
+  },
+  hooks: {
+    afterChange: [syncRelatedModelsOnPostChange],
+    afterDelete: [removePostFromRelatedModelsOnDelete],
   },
 };

--- a/src/migrations/20260731_restore_models_related_posts.ts
+++ b/src/migrations/20260731_restore_models_related_posts.ts
@@ -1,0 +1,32 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Restore models.relatedPosts relationship rows from posts.relatedModels so
+ * both sides can edit the link again (join-only reverse UI was insufficient).
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO "models_rels" ("order", "parent_id", "path", "posts_id")
+    SELECT
+      pr."order",
+      pr."models_id",
+      'relatedPosts',
+      pr."parent_id"
+    FROM "posts_rels" pr
+    WHERE pr."path" = 'relatedModels'
+      AND pr."models_id" IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "models_rels" mr
+        WHERE mr."parent_id" = pr."models_id"
+          AND mr."path" = 'relatedPosts'
+          AND mr."posts_id" = pr."parent_id"
+      );
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DELETE FROM "models_rels" WHERE "path" = 'relatedPosts';
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -3,6 +3,7 @@ import * as migration_20260727_article_relations from './20260727_article_relati
 import * as migration_20260727_article_relations_repair from './20260727_article_relations_repair';
 import * as migration_20260727_twofactor_lockout from './20260727_twofactor_lockout';
 import * as migration_20260731_models_related_posts_join from './20260731_models_related_posts_join';
+import * as migration_20260731_restore_models_related_posts from './20260731_restore_models_related_posts';
 
 export const migrations = [
   {
@@ -29,5 +30,10 @@ export const migrations = [
     up: migration_20260731_models_related_posts_join.up,
     down: migration_20260731_models_related_posts_join.down,
     name: '20260731_models_related_posts_join',
+  },
+  {
+    up: migration_20260731_restore_models_related_posts.up,
+    down: migration_20260731_restore_models_related_posts.down,
+    name: '20260731_restore_models_related_posts',
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -118,9 +118,6 @@ export interface Config {
     kits: {
       models: 'models';
     };
-    models: {
-      relatedPosts: 'posts';
-    };
     'payload-folders': {
       documentsAndFolders: 'payload-folders' | 'media';
     };
@@ -432,7 +429,7 @@ export interface Post {
   tags?: (number | PostsTag)[] | null;
   relatedPosts?: (number | Post)[] | null;
   /**
-   * Link models to this article. Shown as Related Articles on the model.
+   * Link models from this article. Also editable from the model.
    */
   relatedModels?: (number | Model)[] | null;
   /**
@@ -525,13 +522,9 @@ export interface Model {
       | null;
   };
   /**
-   * Articles that link to this model. Add or remove links from the article sidebar.
+   * Link articles from this model. Also editable from the article.
    */
-  relatedPosts?: {
-    docs?: (number | Post)[];
-    hasNextPage?: boolean;
-    totalDocs?: number;
-  };
+  relatedPosts?: (number | Post)[] | null;
   relatedResources?: {
     relatedModels?: (number | Model)[] | null;
   };

--- a/src/utilities/normalizeRelationIds.ts
+++ b/src/utilities/normalizeRelationIds.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalize Payload relationship values (ids or populated docs) to a unique id list.
+ */
+export const normalizeRelationIds = (value: unknown): number[] => {
+  if (!Array.isArray(value)) return []
+
+  const ids = value
+    .map((item) => {
+      if (typeof item === 'number') return item
+      if (typeof item === 'string' && item !== '' && !Number.isNaN(Number(item))) {
+        return Number(item)
+      }
+      if (item && typeof item === 'object' && 'id' in item) {
+        const id = (item as { id: unknown }).id
+        if (typeof id === 'number') return id
+        if (typeof id === 'string' && id !== '' && !Number.isNaN(Number(id))) {
+          return Number(id)
+        }
+      }
+      return null
+    })
+    .filter((id): id is number => id != null)
+
+  return [...new Set(ids)]
+}

--- a/src/utilities/relationSync.ts
+++ b/src/utilities/relationSync.ts
@@ -1,0 +1,37 @@
+import type { PayloadRequest } from 'payload'
+import { normalizeRelationIds } from './normalizeRelationIds'
+
+export type RelationSyncContext = {
+  skipRelationSync?: boolean
+}
+
+export const idsEqual = (a: number[], b: number[]) => {
+  if (a.length !== b.length) return false
+  const sortedA = [...a].sort((x, y) => x - y)
+  const sortedB = [...b].sort((x, y) => x - y)
+  return sortedA.every((id, index) => id === sortedB[index])
+}
+
+/** Autosave fires afterChange too; syncing there races drafts/locks and hangs the admin save. */
+export function isAutosaveRequest(req: PayloadRequest): boolean {
+  const query = (req as { query?: Record<string, unknown> }).query
+  if (query?.autosave === true || query?.autosave === 'true') return true
+
+  if (req.url) {
+    try {
+      const url = new URL(req.url, 'http://local')
+      if (url.searchParams.get('autosave') === 'true') return true
+    } catch {
+      // ignore invalid url
+    }
+  }
+
+  return false
+}
+
+export function shouldSkipRelationSync(req: PayloadRequest, context: unknown): boolean {
+  const syncContext = context as RelationSyncContext
+  return Boolean(syncContext?.skipRelationSync) || isAutosaveRequest(req)
+}
+
+export { normalizeRelationIds }


### PR DESCRIPTION
Join fields only showed reverse links; dual relationships with sync hooks (skipping autosave) let either side edit the link without hanging saves.