### PR TITLE
Fix article–model save hang by joining Postgres transactions

### DIFF
--- a/src/collections/Models/Models/hooks/syncRelatedPosts.ts
+++ b/src/collections/Models/Models/hooks/syncRelatedPosts.ts
@@ -8,16 +8,18 @@ import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'paylo
 /**
  * Keep Posts.relatedModels in sync when a model's relatedPosts change.
  *
- * Nested post updates omit `req` (separate from the model transaction) and use
- * overrideLock so draft/autosave locks on articles don't block the model save.
+ * Nested Local API calls must pass `req` so they join the parent Postgres
+ * transaction — omitting it opens a second transaction and deadlocks the save.
+ * overrideLock avoids draft locks on articles blocking the model save.
  */
 export const syncRelatedPostsOnModelChange: CollectionAfterChangeHook = async ({
   doc,
   previousDoc,
   req,
   context,
+  operation,
 }) => {
-  if (shouldSkipRelationSync(req, context) || doc?.id == null) return doc
+  if (shouldSkipRelationSync(req, context, operation) || doc?.id == null) return doc
 
   const modelId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
   if (Number.isNaN(modelId)) return doc
@@ -38,6 +40,7 @@ export const syncRelatedPostsOnModelChange: CollectionAfterChangeHook = async ({
         id: postId,
         depth: 0,
         overrideAccess: true,
+        req,
       })
 
       const currentModels = normalizeRelationIds(post.relatedModels)
@@ -53,6 +56,7 @@ export const syncRelatedPostsOnModelChange: CollectionAfterChangeHook = async ({
         overrideAccess: true,
         overrideLock: true,
         context: { skipRelationSync: true },
+        req,
       })
     } catch (err) {
       payload.logger.error({
@@ -69,6 +73,7 @@ export const syncRelatedPostsOnModelChange: CollectionAfterChangeHook = async ({
         id: postId,
         depth: 0,
         overrideAccess: true,
+        req,
       })
 
       const currentModels = normalizeRelationIds(post.relatedModels)
@@ -84,6 +89,7 @@ export const syncRelatedPostsOnModelChange: CollectionAfterChangeHook = async ({
         overrideAccess: true,
         overrideLock: true,
         context: { skipRelationSync: true },
+        req,
       })
     } catch (err) {
       payload.logger.error({
@@ -117,6 +123,7 @@ export const removeModelFromRelatedPostsOnDelete: CollectionAfterDeleteHook = as
         id: postId,
         depth: 0,
         overrideAccess: true,
+        req,
       })
 
       const currentModels = normalizeRelationIds(post.relatedModels)
@@ -132,6 +139,7 @@ export const removeModelFromRelatedPostsOnDelete: CollectionAfterDeleteHook = as
         overrideAccess: true,
         overrideLock: true,
         context: { skipRelationSync: true },
+        req,
       })
     } catch (err) {
       payload.logger.error({

--- a/src/collections/Posts/Posts/hooks/syncRelatedModels.ts
+++ b/src/collections/Posts/Posts/hooks/syncRelatedModels.ts
@@ -8,16 +8,17 @@ import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'paylo
 /**
  * Keep Models.relatedPosts in sync when an article's relatedModels change.
  *
- * Nested updates intentionally omit `req` so they run outside the parent
- * transaction (avoids lock contention with draft/versioned post saves).
+ * Nested Local API calls must pass `req` so they join the parent Postgres
+ * transaction — omitting it opens a second transaction and deadlocks the save.
  */
 export const syncRelatedModelsOnPostChange: CollectionAfterChangeHook = async ({
   doc,
   previousDoc,
   req,
   context,
+  operation,
 }) => {
-  if (shouldSkipRelationSync(req, context) || doc?.id == null) return doc
+  if (shouldSkipRelationSync(req, context, operation) || doc?.id == null) return doc
 
   const postId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
   if (Number.isNaN(postId)) return doc
@@ -38,6 +39,7 @@ export const syncRelatedModelsOnPostChange: CollectionAfterChangeHook = async ({
         id: modelId,
         depth: 0,
         overrideAccess: true,
+        req,
       })
 
       const currentPosts = normalizeRelationIds(model.relatedPosts)
@@ -52,6 +54,7 @@ export const syncRelatedModelsOnPostChange: CollectionAfterChangeHook = async ({
         depth: 0,
         overrideAccess: true,
         context: { skipRelationSync: true },
+        req,
       })
     } catch (err) {
       payload.logger.error({
@@ -68,6 +71,7 @@ export const syncRelatedModelsOnPostChange: CollectionAfterChangeHook = async ({
         id: modelId,
         depth: 0,
         overrideAccess: true,
+        req,
       })
 
       const currentPosts = normalizeRelationIds(model.relatedPosts)
@@ -82,6 +86,7 @@ export const syncRelatedModelsOnPostChange: CollectionAfterChangeHook = async ({
         depth: 0,
         overrideAccess: true,
         context: { skipRelationSync: true },
+        req,
       })
     } catch (err) {
       payload.logger.error({
@@ -115,6 +120,7 @@ export const removePostFromRelatedModelsOnDelete: CollectionAfterDeleteHook = as
         id: modelId,
         depth: 0,
         overrideAccess: true,
+        req,
       })
 
       const currentPosts = normalizeRelationIds(model.relatedPosts)
@@ -129,6 +135,7 @@ export const removePostFromRelatedModelsOnDelete: CollectionAfterDeleteHook = as
         depth: 0,
         overrideAccess: true,
         context: { skipRelationSync: true },
+        req,
       })
     } catch (err) {
       payload.logger.error({

--- a/src/utilities/relationSync.ts
+++ b/src/utilities/relationSync.ts
@@ -12,10 +12,13 @@ export const idsEqual = (a: number[], b: number[]) => {
   return sortedA.every((id, index) => id === sortedB[index])
 }
 
-/** Autosave fires afterChange too; syncing there races drafts/locks and hangs the admin save. */
+/** Autosave fires afterChange too; skip sync there to keep keystroke saves light. */
 export function isAutosaveRequest(req: PayloadRequest): boolean {
   const query = (req as { query?: Record<string, unknown> }).query
   if (query?.autosave === true || query?.autosave === 'true') return true
+
+  const search = (req as { searchParams?: URLSearchParams }).searchParams
+  if (search?.get?.('autosave') === 'true') return true
 
   if (req.url) {
     try {
@@ -29,9 +32,17 @@ export function isAutosaveRequest(req: PayloadRequest): boolean {
   return false
 }
 
-export function shouldSkipRelationSync(req: PayloadRequest, context: unknown): boolean {
+export function shouldSkipRelationSync(
+  req: PayloadRequest,
+  context: unknown,
+  operation?: string,
+): boolean {
   const syncContext = context as RelationSyncContext
-  return Boolean(syncContext?.skipRelationSync) || isAutosaveRequest(req)
+  return (
+    Boolean(syncContext?.skipRelationSync) ||
+    operation === 'autosave' ||
+    isAutosaveRequest(req)
+  )
 }
 
 export { normalizeRelationIds }


### PR DESCRIPTION
Nested Local API updates must pass req; omitting it started a second transaction and deadlocked the admin save. Also skip sync on autosave ops.