### PR TITLE
Add migration for gallery album defaultSort column.

### DIFF
--- a/src/migrations/20260805_gallery_albums_default_sort.ts
+++ b/src/migrations/20260805_gallery_albums_default_sort.ts
@@ -1,0 +1,41 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Add per-album default image sort setting.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_gallery_albums_settings_default_sort" AS ENUM(
+        '-createdAt',
+        'createdAt',
+        'filename',
+        '-filename'
+      );
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+
+    ALTER TABLE "gallery_albums"
+      ADD COLUMN IF NOT EXISTS "settings_default_sort"
+      "enum_gallery_albums_settings_default_sort"
+      DEFAULT '-createdAt';
+
+    UPDATE "gallery_albums"
+      SET "settings_default_sort" = '-createdAt'
+      WHERE "settings_default_sort" IS NULL;
+
+    ALTER TABLE "gallery_albums"
+      ALTER COLUMN "settings_default_sort" SET DEFAULT '-createdAt';
+
+    ALTER TABLE "gallery_albums"
+      ALTER COLUMN "settings_default_sort" SET NOT NULL;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "gallery_albums" DROP COLUMN IF EXISTS "settings_default_sort";
+    DROP TYPE IF EXISTS "public"."enum_gallery_albums_settings_default_sort";
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -4,6 +4,7 @@ import * as migration_20260727_article_relations_repair from './20260727_article
 import * as migration_20260727_twofactor_lockout from './20260727_twofactor_lockout';
 import * as migration_20260731_models_related_posts_join from './20260731_models_related_posts_join';
 import * as migration_20260731_restore_models_related_posts from './20260731_restore_models_related_posts';
+import * as migration_20260805_gallery_albums_default_sort from './20260805_gallery_albums_default_sort';
 
 export const migrations = [
   {
@@ -35,5 +36,10 @@ export const migrations = [
     up: migration_20260731_restore_models_related_posts.up,
     down: migration_20260731_restore_models_related_posts.down,
     name: '20260731_restore_models_related_posts',
+  },
+  {
+    up: migration_20260805_gallery_albums_default_sort.up,
+    down: migration_20260805_gallery_albums_default_sort.down,
+    name: '20260805_gallery_albums_default_sort',
   },
 ];


### PR DESCRIPTION
The new settings.defaultSort field was querying a missing DB column and blanking the albums admin.