### PR TITLE
fix: namespace media and gallery-images R2 uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-itsmillertime-dev",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/collections/Gallery/Image/index.ts
+++ b/src/collections/Gallery/Image/index.ts
@@ -16,10 +16,31 @@ import { type CollectionConfig } from 'payload';
 import { generateEXIF } from '@/collections/shared/generateEXIF';
 import { generateBlurHash } from '@/collections/shared/generateBlurHash';
 import { defaultAltText } from '@/collections/shared/defaultAltText';
+import { ensureUploadPrefix } from '@/collections/shared/ensureUploadPrefix';
 import { visibilityFilter } from '@/access/filters/visibilityFilter';
 import { allowAll } from '@/access/methods/allowAll';
 import { allowedRoles } from '@/access/methods/allowedRoles';
 
+/**
+ * R2 / S3 key namespacing (shared bucket with media):
+ *
+ * Media and gallery-images share one Cloudflare R2 bucket. Filenames alone are not
+ * unique across collections, so same-name uploads used to overwrite each other.
+ *
+ * We use a document-level `prefix` (default `gallery-images`) so NEW uploads land
+ * under `gallery-images/…`. Existing docs keep NULL/empty prefix and still resolve
+ * at the bucket root — do NOT set collection-level `prefix` in `s3Storage` yet, or
+ * those root keys break (Payload falls back to collection prefix when doc prefix
+ * is empty).
+ *
+ * Overwritten root objects cannot be recovered; re-upload those assets.
+ *
+ * Future: once every live Gallery Image asset lives under `gallery-images/`
+ * (re-upload through the CMS, or move objects +
+ * `UPDATE gallery_images SET prefix = 'gallery-images' WHERE prefix IS NULL`),
+ * set `prefix: 'gallery-images'` on the gallery-images entry in
+ * `src/plugins/index.ts` s3Storage config.
+ */
 export const GalleryImages: CollectionConfig<'gallery-images'> = {
   slug: 'gallery-images',
   admin: {
@@ -44,6 +65,16 @@ export const GalleryImages: CollectionConfig<'gallery-images'> = {
   },
   upload: baseUploadConfig,
   fields: [
+    // Document R2 prefix — see collection comment above. Leave NULL on legacy root docs.
+    {
+      name: 'prefix',
+      type: 'text',
+      defaultValue: 'gallery-images',
+      admin: {
+        hidden: true,
+        readOnly: true,
+      },
+    },
     {
       type: 'group',
       name: 'settings',
@@ -252,6 +283,7 @@ export const GalleryImages: CollectionConfig<'gallery-images'> = {
   hooks: {
     afterChange: [generateEXIF],
     afterDelete: [removeMedusaProduct],
+    beforeChange: [ensureUploadPrefix('gallery-images')],
     beforeValidate: [defaultAltText, generateBlurHash],
   },
 };

--- a/src/collections/Media/Media.ts
+++ b/src/collections/Media/Media.ts
@@ -3,12 +3,30 @@ import { Groups } from '../shared/groups';
 import { imageContentFields, imageTechnicalFields } from '../shared/imageFields';
 import { baseUploadConfig } from '../shared/uploadConfig';
 import { defaultAltText } from '../shared/defaultAltText';
+import { ensureUploadPrefix } from '../shared/ensureUploadPrefix';
 import { generateBlurHash } from '../shared/generateBlurHash';
 import { generateEXIF } from '../shared/generateEXIF';
 import { RBAC } from '@/access/RBAC';
 import { allowAll } from '@/access/methods/allowAll';
 import { allowedRoles } from '@/access/methods/allowedRoles';
 
+/**
+ * R2 / S3 key namespacing (shared bucket with gallery-images):
+ *
+ * Media and gallery-images share one Cloudflare R2 bucket. Filenames alone are not
+ * unique across collections, so same-name uploads used to overwrite each other.
+ *
+ * We use a document-level `prefix` (default `media`) so NEW uploads land under
+ * `media/…`. Existing docs keep NULL/empty prefix and still resolve at the bucket
+ * root — do NOT set collection-level `prefix` in `s3Storage` yet, or those root
+ * keys break (Payload falls back to collection prefix when doc prefix is empty).
+ *
+ * Overwritten root objects cannot be recovered; re-upload those assets.
+ *
+ * Future: once every live Media asset lives under `media/` (re-upload through the
+ * CMS, or move objects + `UPDATE media SET prefix = 'media' WHERE prefix IS NULL`),
+ * set `prefix: 'media'` on the media entry in `src/plugins/index.ts` s3Storage config.
+ */
 export const Media: CollectionConfig = {
   slug: 'media',
   admin: {
@@ -30,6 +48,16 @@ export const Media: CollectionConfig = {
     admin: RBAC(allowedRoles(['admin']), [], 'media', 'admin'),
   },
   fields: [
+    // Document R2 prefix — see collection comment above. Leave NULL on legacy root docs.
+    {
+      name: 'prefix',
+      type: 'text',
+      defaultValue: 'media',
+      admin: {
+        hidden: true,
+        readOnly: true,
+      },
+    },
     ...imageTechnicalFields,
     {
       type: 'tabs',
@@ -59,6 +87,7 @@ export const Media: CollectionConfig = {
   upload: baseUploadConfig,
   hooks: {
     afterChange: [generateEXIF],
+    beforeChange: [ensureUploadPrefix('media')],
     beforeValidate: [defaultAltText, generateBlurHash],
   },
 };

--- a/src/collections/shared/ensureUploadPrefix.ts
+++ b/src/collections/shared/ensureUploadPrefix.ts
@@ -1,0 +1,26 @@
+import type { CollectionBeforeChangeHook } from 'payload';
+
+/**
+ * Ensures upload docs get a document-level R2/S3 prefix on create and re-upload.
+ * Existing root (prefix-less) docs keep working until they receive a new file.
+ */
+export const ensureUploadPrefix =
+  (uploadPrefix: string): CollectionBeforeChangeHook =>
+  ({ data, operation, originalDoc, req }) => {
+    if (!data) return data;
+
+    // Preserve an existing stored prefix on updates that omit it
+    if (!data.prefix && originalDoc && typeof originalDoc.prefix === 'string' && originalDoc.prefix) {
+      data.prefix = originalDoc.prefix;
+      return data;
+    }
+
+    const hasIncomingFile = Boolean(req.file);
+    const prefixMissing = !data.prefix;
+
+    if (prefixMissing && (operation === 'create' || hasIncomingFile)) {
+      data.prefix = uploadPrefix;
+    }
+
+    return data;
+  };

--- a/src/migrations/20260805_upload_collection_prefixes.ts
+++ b/src/migrations/20260805_upload_collection_prefixes.ts
@@ -1,0 +1,22 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Add document-level R2/S3 prefix columns for media and gallery-images.
+ * Existing rows stay NULL so legacy root-key objects keep resolving.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "media"
+      ADD COLUMN IF NOT EXISTS "prefix" varchar;
+
+    ALTER TABLE "gallery_images"
+      ADD COLUMN IF NOT EXISTS "prefix" varchar;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "media" DROP COLUMN IF EXISTS "prefix";
+    ALTER TABLE "gallery_images" DROP COLUMN IF EXISTS "prefix";
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -5,6 +5,7 @@ import * as migration_20260727_twofactor_lockout from './20260727_twofactor_lock
 import * as migration_20260731_models_related_posts_join from './20260731_models_related_posts_join';
 import * as migration_20260731_restore_models_related_posts from './20260731_restore_models_related_posts';
 import * as migration_20260805_gallery_albums_default_sort from './20260805_gallery_albums_default_sort';
+import * as migration_20260805_upload_collection_prefixes from './20260805_upload_collection_prefixes';
 
 export const migrations = [
   {
@@ -41,5 +42,10 @@ export const migrations = [
     up: migration_20260805_gallery_albums_default_sort.up,
     down: migration_20260805_gallery_albums_default_sort.down,
     name: '20260805_gallery_albums_default_sort',
+  },
+  {
+    up: migration_20260805_upload_collection_prefixes.up,
+    down: migration_20260805_upload_collection_prefixes.down,
+    name: '20260805_upload_collection_prefixes',
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -571,6 +571,7 @@ export interface Model {
  */
 export interface Media {
   id: number;
+  prefix?: string | null;
   exif?:
     | {
         [k: string]: unknown;
@@ -776,6 +777,7 @@ export interface ModelsTag {
  */
 export interface GalleryImage {
   id: number;
+  prefix?: string | null;
   settings: {
     isNsfw?: boolean | null;
     'gallery-tags'?: (number | GalleryTag)[] | null;
@@ -1986,6 +1988,7 @@ export interface UsersSelect<T extends boolean = true> {
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
+  prefix?: T;
   exif?: T;
   blurhash?: T;
   alt?: T;
@@ -2206,6 +2209,7 @@ export interface GalleryAlbumsSelect<T extends boolean = true> {
  * via the `definition` "gallery-images_select".
  */
 export interface GalleryImagesSelect<T extends boolean = true> {
+  prefix?: T;
   settings?:
     | T
     | {


### PR DESCRIPTION
## Summary
- Stop Media and Gallery Images from overwriting each other in the shared Cloudflare R2 bucket by storing document-level `prefix` values (`media` / `gallery-images`) on new uploads
- Leave existing root-key assets intact (NULL prefix) so current URLs keep working; collection-level `s3Storage` prefixes are deferred until the root is clear
- Add migration for `media.prefix` and `gallery_images.prefix`, plus comments documenting the future config switch

## Test plan
- [ ] Run `pnpm payload migrate`
- [ ] Upload the same filename to Media and Gallery Images; confirm distinct R2 keys (`media/...` vs `gallery-images/...`)
- [ ] Open an older pre-fix asset; confirm it still loads from the bucket root
- [ ] Re-upload an overwritten Media item; confirm it lands under `media/` and no longer collides with Gallery


Made with [Cursor](https://cursor.com)