### PR TITLE
feat: Authentik OIDC login via Better Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # cms-itsmillertime-dev
 
+## 3.23.0
+
+### Minor Changes
+
+- Add Authentik OIDC login via Better Auth (genericOAuth), with local email/password as break-glass
+- Remove GitHub and Discord social providers
+- Auto-provision users on first Authentik login as role `user`
+- Disable public email signup
+
 ## 3.18.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The headless CMS powering [itsmillertime.dev](https://www.itsmillertime.dev), bu
 | `payload-plugin-webhooks` | Webhook delivery on collection events |
 | `payload-sidebar-plugin` | Custom admin sidebar with grouped navigation and icons |
 | `@veiag/payload-cmdk` | Command palette (Cmd+K) in the admin panel |
+| `@delmaredigital/payload-better-auth` | Better Auth sessions; Authentik OIDC + local email/password |
 
 ## API Documentation
 
@@ -142,6 +143,19 @@ CONTACT_EMAIL=you@example.com
 # Sentry
 SENTRY_ORG=your-org
 SENTRY_PROJECT=your-project
+
+# Better Auth
+BETTER_AUTH_SECRET=generate-a-long-random-secret
+BETTER_AUTH_URL=http://localhost:3000
+
+# Authentik OIDC (optional until the application/provider exists)
+# Discovery URL shape:
+# https://auth.itsmillertime.dev/application/o/<app-slug>/.well-known/openid-configuration
+# Callback URL to register in Authentik:
+# {BETTER_AUTH_URL}/api/auth/oauth2/callback/authentik
+AUTHENTIK_CLIENT_ID=
+AUTHENTIK_CLIENT_SECRET=
+AUTHENTIK_DISCOVERY_URL=
 ```
 
 ### Installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-itsmillertime-dev",
-  "version": "3.22.1",
+  "version": "3.23.0",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -63,7 +63,7 @@ import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe76
 import { CommandMenuProvider as CommandMenuProvider_3bf5d3e334c5eaf4f0d216451590d3c2 } from '@veiag/payload-cmdk/client'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 import { default as default_41e34effe3f4ece2ddcb2839119d86bb } from '@/components/BGG'
-import { LoginViewWrapperWithPasskey as LoginViewWrapperWithPasskey_32122ff130abf1886fc6ac22c8c20952 } from '@delmaredigital/payload-better-auth/components/login-passkey'
+import { AuthentikLoginViewWrapper as AuthentikLoginViewWrapper_ec378eedda62e1fa662ddd95e7b51280 } from '@/components/auth/AuthentikLoginViewWrapper'
 import { ApiKeysView as ApiKeysView_6234f869b6abd89bf631f5883bc67bd5 } from '@delmaredigital/payload-better-auth/rsc/api-key'
 import { default as default_838fb0a30eb441ddfea0c8d82d1e35c3 } from '@/components/Dashboard/widgets/AnalyticsWidget'
 import { default as default_f295ca6a3d97191f9cda7f6e79f83657 } from '@/components/Dashboard/widgets/RecentContentWidget'
@@ -137,7 +137,7 @@ export const importMap = {
   "@veiag/payload-cmdk/client#CommandMenuProvider": CommandMenuProvider_3bf5d3e334c5eaf4f0d216451590d3c2,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24,
   "@/components/BGG#default": default_41e34effe3f4ece2ddcb2839119d86bb,
-  "@delmaredigital/payload-better-auth/components/login-passkey#LoginViewWrapperWithPasskey": LoginViewWrapperWithPasskey_32122ff130abf1886fc6ac22c8c20952,
+  "@/components/auth/AuthentikLoginViewWrapper#AuthentikLoginViewWrapper": AuthentikLoginViewWrapper_ec378eedda62e1fa662ddd95e7b51280,
   "@delmaredigital/payload-better-auth/rsc/api-key#ApiKeysView": ApiKeysView_6234f869b6abd89bf631f5883bc67bd5,
   "@/components/Dashboard/widgets/AnalyticsWidget#default": default_838fb0a30eb441ddfea0c8d82d1e35c3,
   "@/components/Dashboard/widgets/RecentContentWidget#default": default_f295ca6a3d97191f9cda7f6e79f83657,

--- a/src/components/auth/AuthentikLoginView.tsx
+++ b/src/components/auth/AuthentikLoginView.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { LoginView, type LoginViewProps } from '@delmaredigital/payload-better-auth/components';
+import { AUTHENTIK_PROVIDER_ID } from '@/lib/auth/authentik-constants';
+import { authClient } from '@/lib/auth/auth-client';
+
+type AuthentikLoginViewProps = Omit<LoginViewProps, 'authClient' | 'logo' | 'socialProviders'> & {
+  authentikEnabled: boolean;
+};
+
+function humanizeOAuthError(code: string): string {
+  const messages: Record<string, string> = {
+    access_denied: 'Access was denied by Authentik.',
+    oauth_provider_not_found: 'Authentik is not configured. Please contact support.',
+    oauth_code_verification_failed: 'Could not complete Authentik sign-in. Please try again.',
+    user_info_is_missing: 'Authentik did not return user information.',
+    email_is_missing: 'Authentik did not share an email address.',
+    unable_to_link_account: 'Could not link this Authentik account to an existing user.',
+  };
+  return messages[code] ?? `Sign-in failed (${code}). Please try again or use local login.`;
+}
+
+function wantsLocalLogin(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('local') === '1';
+}
+
+export function AuthentikLoginView({
+  authentikEnabled,
+  title = 'Admin Login',
+  afterLoginPath = '/admin',
+  ...loginProps
+}: AuthentikLoginViewProps) {
+  const [authentikLoading, setAuthentikLoading] = useState(false);
+  const [authentikError, setAuthentikError] = useState<string | null>(null);
+  const [showLocal, setShowLocal] = useState(() => !authentikEnabled || wantsLocalLogin());
+
+  useEffect(() => {
+    if (!authentikEnabled) {
+      setShowLocal(true);
+      return;
+    }
+    setShowLocal(wantsLocalLogin());
+  }, [authentikEnabled]);
+
+  useEffect(() => {
+    if (!authentikEnabled || typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get('error');
+    if (!error) return;
+    setAuthentikError(humanizeOAuthError(error));
+    params.delete('error');
+    params.delete('error_description');
+    const next = `${window.location.pathname}${params.toString() ? `?${params}` : ''}`;
+    window.history.replaceState({}, '', next);
+  }, [authentikEnabled]);
+
+  async function handleAuthentikSignIn() {
+    if (authentikLoading) return;
+    setAuthentikLoading(true);
+    setAuthentikError(null);
+
+    const loginUrl =
+      typeof window !== 'undefined' ? window.location.href.split('?')[0]! : '/admin/login';
+
+    try {
+      const result = await authClient.signIn.oauth2({
+        providerId: AUTHENTIK_PROVIDER_ID,
+        callbackURL: loginUrl,
+        errorCallbackURL: loginUrl,
+      });
+
+      if (result.error) {
+        setAuthentikError(result.error.message || 'Authentik sign-in failed.');
+        setAuthentikLoading(false);
+        return;
+      }
+
+      // Better Auth returns { url, redirect } when it does not navigate itself.
+      const data = result.data as { url?: string; redirect?: boolean } | undefined;
+      if (data?.url) {
+        window.location.href = data.url;
+        return;
+      }
+    } catch (error) {
+      setAuthentikError(error instanceof Error ? error.message : 'Authentik sign-in failed.');
+      setAuthentikLoading(false);
+    }
+  }
+
+  function openLocalLogin() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('local', '1');
+    window.history.replaceState({}, '', url.toString());
+    setShowLocal(true);
+  }
+
+  function backToAuthentik() {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('local');
+    window.history.replaceState({}, '', url.toString());
+    setShowLocal(false);
+  }
+
+  if (!authentikEnabled || showLocal) {
+    return (
+      <div>
+        {authentikEnabled && (
+          <div
+            style={{
+              position: 'fixed',
+              top: 'calc(var(--base) * 1)',
+              left: 0,
+              right: 0,
+              zIndex: 10,
+              textAlign: 'center',
+            }}
+          >
+            <button
+              type="button"
+              onClick={backToAuthentik}
+              style={{
+                background: 'none',
+                border: 'none',
+                color: 'var(--theme-text)',
+                opacity: 0.8,
+                cursor: 'pointer',
+                fontSize: 'var(--font-size-small)',
+                textDecoration: 'underline',
+              }}
+            >
+              ← Back to Authentik login
+            </button>
+          </div>
+        )}
+        <LoginView
+          {...loginProps}
+          title={authentikEnabled ? 'Local login' : title}
+          afterLoginPath={afterLoginPath}
+          authClient={authClient}
+          socialProviders={[]}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--theme-bg)',
+        padding: 'var(--base)',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: '400px',
+          padding: 'calc(var(--base) * 2)',
+          borderRadius: 'var(--style-radius-m)',
+          background: 'var(--theme-elevation-50)',
+          boxShadow: '0 2px 20px rgba(0, 0, 0, 0.1)',
+        }}
+      >
+        <h1
+          style={{
+            color: 'var(--theme-text)',
+            fontSize: 'var(--font-size-h3)',
+            fontWeight: 600,
+            textAlign: 'center',
+            margin: '0 0 calc(var(--base) * 1.5) 0',
+          }}
+        >
+          {title}
+        </h1>
+
+        {authentikError && (
+          <div
+            role="alert"
+            style={{
+              marginBottom: 'calc(var(--base) * 1)',
+              padding: 'calc(var(--base) * 0.75)',
+              borderRadius: 'var(--style-radius-s)',
+              background: 'var(--theme-error-100, #fee2e2)',
+              color: 'var(--theme-error-750, #991b1b)',
+              fontSize: 'var(--font-size-small)',
+            }}
+          >
+            {authentikError}
+          </div>
+        )}
+
+        <button
+          type="button"
+          disabled={authentikLoading}
+          onClick={handleAuthentikSignIn}
+          style={{
+            width: '100%',
+            padding: 'calc(var(--base) * 0.75)',
+            borderRadius: 'var(--style-radius-s)',
+            fontSize: 'var(--font-size-base)',
+            fontWeight: 500,
+            cursor: authentikLoading ? 'not-allowed' : 'pointer',
+            opacity: authentikLoading ? 0.7 : 1,
+            background: 'var(--theme-elevation-800)',
+            border: 'none',
+            color: 'var(--theme-elevation-50)',
+          }}
+        >
+          {authentikLoading ? 'Redirecting to Authentik…' : 'Continue with Authentik'}
+        </button>
+
+        <p
+          style={{
+            margin: 'calc(var(--base) * 1.25) 0 calc(var(--base) * 1)',
+            textAlign: 'center',
+            fontSize: 'var(--font-size-small)',
+            color: 'var(--theme-text)',
+            opacity: 0.7,
+          }}
+        >
+          Sign in with your itsmillertime.dev identity
+        </p>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'calc(var(--base) * 0.75)',
+            margin: 'calc(var(--base) * 0.5) 0',
+            color: 'var(--theme-text)',
+            opacity: 0.5,
+            fontSize: 'var(--font-size-small)',
+          }}
+        >
+          <div style={{ flex: 1, height: 1, background: 'var(--theme-elevation-250)' }} />
+          or
+          <div style={{ flex: 1, height: 1, background: 'var(--theme-elevation-250)' }} />
+        </div>
+
+        <button
+          type="button"
+          onClick={openLocalLogin}
+          style={{
+            width: '100%',
+            padding: 'calc(var(--base) * 0.75)',
+            borderRadius: 'var(--style-radius-s)',
+            fontSize: 'var(--font-size-base)',
+            fontWeight: 500,
+            cursor: 'pointer',
+            background: 'transparent',
+            border: '1px solid var(--theme-elevation-300)',
+            color: 'var(--theme-text)',
+          }}
+        >
+          Use local email &amp; password
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default AuthentikLoginView;

--- a/src/components/auth/AuthentikLoginViewWrapper.tsx
+++ b/src/components/auth/AuthentikLoginViewWrapper.tsx
@@ -1,0 +1,44 @@
+import type { AdminViewServerProps } from 'payload';
+import { isAuthentikConfigured } from '@/lib/auth/authentik';
+import { AuthentikLoginView } from './AuthentikLoginView';
+
+type LoginConfig = {
+  title?: string;
+  afterLoginPath?: string;
+  requiredRole?: string | string[] | null;
+  requireAllRoles?: boolean;
+  enablePasskey?: boolean | 'auto';
+  enableSignUp?: boolean | 'auto';
+  enableForgotPassword?: boolean | 'auto';
+  enablePassword?: boolean | 'auto';
+  resetPasswordUrl?: string;
+};
+
+/**
+ * Admin login view: Authentik OIDC primary when configured, with local
+ * email/password (+ passkey) as break-glass under a disclosure.
+ */
+export async function AuthentikLoginViewWrapper({ initPageResult }: AdminViewServerProps) {
+  const { payload } = initPageResult.req;
+  const loginConfig = (payload.config.custom?.betterAuth?.login ?? {}) as LoginConfig;
+  const authentikEnabled = isAuthentikConfigured();
+
+  return (
+    <AuthentikLoginView
+      authentikEnabled={authentikEnabled}
+      title={loginConfig.title ?? 'Admin Login'}
+      afterLoginPath={loginConfig.afterLoginPath ?? '/admin'}
+      requiredRole={loginConfig.requiredRole ?? ['admin']}
+      requireAllRoles={loginConfig.requireAllRoles ?? false}
+      enablePasskey={loginConfig.enablePasskey ?? true}
+      enableSignUp={false}
+      enableForgotPassword={loginConfig.enableForgotPassword ?? true}
+      enablePassword={loginConfig.enablePassword ?? true}
+      enableMagicLink={false}
+      enableEmailOtp={false}
+      resetPasswordUrl={loginConfig.resetPasswordUrl}
+    />
+  );
+}
+
+export default AuthentikLoginViewWrapper;

--- a/src/lib/auth/auth-client.ts
+++ b/src/lib/auth/auth-client.ts
@@ -3,8 +3,9 @@
 import { apiKeyClient } from '@better-auth/api-key/client';
 import { passkeyClient } from '@better-auth/passkey/client';
 import { createAuthClient, twoFactorClient } from '@delmaredigital/payload-better-auth/client';
+import { genericOAuthClient } from 'better-auth/client/plugins';
 
 export const authClient = createAuthClient({
-  plugins: [twoFactorClient(), passkeyClient(), apiKeyClient()],
+  plugins: [twoFactorClient(), passkeyClient(), apiKeyClient(), genericOAuthClient()],
 });
 export const { useSession, signIn, signUp, signOut, twoFactor, passkey } = authClient;

--- a/src/lib/auth/authentik-constants.ts
+++ b/src/lib/auth/authentik-constants.ts
@@ -1,0 +1,1 @@
+export const AUTHENTIK_PROVIDER_ID = 'authentik' as const;

--- a/src/lib/auth/authentik.ts
+++ b/src/lib/auth/authentik.ts
@@ -1,0 +1,41 @@
+import { AUTHENTIK_PROVIDER_ID } from './authentik-constants';
+
+export { AUTHENTIK_PROVIDER_ID };
+
+export type AuthentikOAuthConfig = {
+  providerId: typeof AUTHENTIK_PROVIDER_ID;
+  clientId: string;
+  clientSecret: string;
+  discoveryUrl: string;
+  scopes: string[];
+  pkce: boolean;
+  requireIssuerValidation: boolean;
+};
+
+/**
+ * Returns Authentik OIDC config when env is complete; otherwise null so local
+ * break-glass login still works before the Authentik app is created.
+ */
+export function getAuthentikOAuthConfig(): AuthentikOAuthConfig | null {
+  const clientId = process.env.AUTHENTIK_CLIENT_ID?.trim();
+  const clientSecret = process.env.AUTHENTIK_CLIENT_SECRET?.trim();
+  const discoveryUrl = process.env.AUTHENTIK_DISCOVERY_URL?.trim();
+
+  if (!clientId || !clientSecret || !discoveryUrl) {
+    return null;
+  }
+
+  return {
+    providerId: AUTHENTIK_PROVIDER_ID,
+    clientId,
+    clientSecret,
+    discoveryUrl,
+    scopes: ['openid', 'profile', 'email'],
+    pkce: true,
+    requireIssuerValidation: true,
+  };
+}
+
+export function isAuthentikConfigured(): boolean {
+  return getAuthentikOAuthConfig() !== null;
+}

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -1,8 +1,10 @@
 import type { BasePayload } from 'payload';
 import { BetterAuthOptions } from 'better-auth';
-import { admin, twoFactor } from 'better-auth/plugins';
+import { admin, genericOAuth, twoFactor } from 'better-auth/plugins';
 import { apiKey } from '@better-auth/api-key';
 import { passkey } from '@better-auth/passkey';
+import { getAuthentikOAuthConfig } from './authentik';
+import { AUTHENTIK_PROVIDER_ID } from './authentik-constants';
 import { getBaseUrl } from './getBaseUrl';
 import { getTrustedOrigins } from './trustedOrigins';
 
@@ -12,6 +14,8 @@ import { getTrustedOrigins } from './trustedOrigins';
  * Callbacks also use setAuthPayload() as fallback when payload is set by createAuth.
  */
 export function createBetterAuthOptions(payload?: BasePayload): Partial<BetterAuthOptions> {
+  const authentik = getAuthentikOAuthConfig();
+
   return {
     trustedOrigins: getTrustedOrigins,
     user: {
@@ -26,6 +30,13 @@ export function createBetterAuthOptions(payload?: BasePayload): Partial<BetterAu
     },
     session: {
       expiresIn: 60 * 60 * 24 * 30, // 30 days
+    },
+    account: {
+      accountLinking: {
+        enabled: true,
+        // Authentik is our trusted IdP — link by email on first OIDC login.
+        trustedProviders: [AUTHENTIK_PROVIDER_ID],
+      },
     },
     emailVerification: {
       sendVerificationEmail: async ({ user, url }) => {
@@ -92,6 +103,8 @@ export function createBetterAuthOptions(payload?: BasePayload): Partial<BetterAu
     emailAndPassword: {
       requireEmailVerification: true,
       enabled: true,
+      // New accounts come from Authentik; keep password for existing/break-glass users.
+      disableSignUp: true,
       revokeSessionsOnPasswordReset: true,
       autoSignIn: true,
       sendResetPassword: async ({ user, url }) => {
@@ -105,18 +118,18 @@ export function createBetterAuthOptions(payload?: BasePayload): Partial<BetterAu
         });
       },
     },
-    socialProviders: {
-      github: {
-        enabled: true,
-        clientId: process.env.GITHUB_CLIENT_ID as string,
-        clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
-      },
-      discord: {
-        enabled: true,
-        clientId: process.env.DISCORD_CLIENT_ID as string,
-        clientSecret: process.env.DISCORD_CLIENT_SECRET as string,
-      },
-    },
-    plugins: [admin(), twoFactor(), passkey(), apiKey({ enableMetadata: true })],
+    plugins: [
+      admin(),
+      twoFactor(),
+      passkey(),
+      apiKey({ enableMetadata: true }),
+      ...(authentik
+        ? [
+            genericOAuth({
+              config: [authentik],
+            }),
+          ]
+        : []),
+    ],
   };
 }

--- a/src/plugins/better-auth.ts
+++ b/src/plugins/better-auth.ts
@@ -42,16 +42,16 @@ export function betterAuthPlugin() {
       admin: {
         betterAuthOptions: createBetterAuthOptions(),
         enableManagementUI: true,
-        // Passkey lives in a separate entry so non-passkey apps don't pull the peer (0.9.1+).
-        loginViewComponent:
-          '@delmaredigital/payload-better-auth/components/login-passkey#LoginViewWrapperWithPasskey',
+        // Authentik-first login; local email/password + passkey remain as break-glass.
+        loginViewComponent: '@/components/auth/AuthentikLoginViewWrapper#AuthentikLoginViewWrapper',
         login: {
           title: 'Admin Login',
           requiredRole: ['admin'],
           requireAllRoles: false,
-          enableSignUp: 'auto',
-          enableForgotPassword: 'auto',
-          enablePasskey: 'auto',
+          enableSignUp: false,
+          enableForgotPassword: true,
+          enablePasskey: true,
+          enablePassword: true,
         },
       },
       autoInjectAdminComponents: true,


### PR DESCRIPTION
## Summary
- Add Authentik as the primary IdP through Better Auth `genericOAuth`, with local email/password (+ passkey) kept as break-glass
- Remove GitHub and Discord social providers; disable public email signup; auto-provision new Authentik users as role `user`
- Bump version to **3.23.0** (no DB migrations — uses existing Better Auth accounts/sessions tables)

## Deploy / config notes
Set these env vars after creating the Authentik application/provider:

```env
AUTHENTIK_CLIENT_ID=
AUTHENTIK_CLIENT_SECRET=
AUTHENTIK_DISCOVERY_URL=https://auth.itsmillertime.dev/application/o/<slug>/.well-known/openid-configuration
```

Authentik redirect URI (Authorization, Strict):
`{BETTER_AUTH_URL}/api/auth/oauth2/callback/authentik`

Until those env vars are set, admin login falls back to local email/password only.

## Test plan
- [ ] Set Authentik env vars on the target environment and restart
- [ ] `/admin/login` shows **Continue with Authentik**
- [ ] Authentik login for an existing admin email links and grants admin access
- [ ] New Authentik user is created as `user` (access denied to admin until promoted)
- [ ] **Use local email & password** (`?local=1`) still works for break-glass
- [ ] Confirm no migration step is required on deploy


Made with [Cursor](https://cursor.com)