### PR TITLE
fix: Authentik login issuer_missing

### DIFF
--- a/src/lib/auth/authentik.ts
+++ b/src/lib/auth/authentik.ts
@@ -9,7 +9,6 @@ export type AuthentikOAuthConfig = {
   discoveryUrl: string;
   scopes: string[];
   pkce: boolean;
-  requireIssuerValidation: boolean;
 };
 
 /**
@@ -32,7 +31,8 @@ export function getAuthentikOAuthConfig(): AuthentikOAuthConfig | null {
     discoveryUrl,
     scopes: ['openid', 'profile', 'email'],
     pkce: true,
-    requireIssuerValidation: true,
+    // Do not set requireIssuerValidation: Authentik often omits RFC 9207 `iss`
+    // on the authorization response, which Better Auth would reject as issuer_missing.
   };
 }
 


### PR DESCRIPTION
## Summary
- Stop requiring RFC 9207 `iss` on the OAuth callback for Authentik
- Fixes `Sign-in failed (issuer_missing)` after Authentik redirects back to the CMS

## Context
Better Auth was configured with `requireIssuerValidation: true`. Authentik frequently does not include `iss` in the authorization response, so the callback failed even though discovery/OIDC itself was fine.

## Test plan
- [ ] Redeploy / restart with this change
- [ ] `/admin/login` → Continue with Authentik completes without `issuer_missing`
- [ ] Local email/password break-glass still works


Made with [Cursor](https://cursor.com)