### PR TITLE
Share better-auth cookies across itsmillertime.dev subdomains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,11 @@ BETTER_AUTH_URL=http://localhost:3000
 # Authentik OIDC (optional until the application/provider exists)
 # Discovery URL shape:
 # https://auth.itsmillertime.dev/application/o/<app-slug>/.well-known/openid-configuration
-# Callback URL to register in Authentik:
+# Callback URL to register in Authentik (CMS direct):
 # {BETTER_AUTH_URL}/api/auth/oauth2/callback/authentik
+# Also register frontend proxy callbacks when www initiates login:
+# https://itsmillertime.dev/api/auth/oauth2/callback/authentik
+# http://localhost:5173/api/auth/oauth2/callback/authentik
 AUTHENTIK_CLIENT_ID=
 AUTHENTIK_CLIENT_SECRET=
 AUTHENTIK_DISCOVERY_URL=

--- a/src/plugins/better-auth.ts
+++ b/src/plugins/better-auth.ts
@@ -57,6 +57,18 @@ export function betterAuthPlugin() {
       autoInjectAdminComponents: true,
       autoRegisterEndpoints: true,
       createAuth: (payload) => {
+        const crossSubDomain =
+          (() => {
+            try {
+              const host = new URL(baseUrl).hostname;
+              return host === 'itsmillertime.dev' || host.endsWith('.itsmillertime.dev')
+                ? '.itsmillertime.dev'
+                : null;
+            } catch {
+              return null;
+            }
+          })();
+
         return betterAuth({
           ...createBetterAuthOptions(payload),
           database: payloadAdapter({
@@ -66,6 +78,17 @@ export function betterAuthPlugin() {
             database: {
               generateId: 'serial',
             },
+            // Honor X-Forwarded-Host from the www auth proxy so OAuth
+            // redirect_uri matches the browser origin (avoids state_mismatch).
+            trustedProxyHeaders: true,
+            ...(crossSubDomain
+              ? {
+                  crossSubDomainCookies: {
+                    enabled: true,
+                    domain: crossSubDomain,
+                  },
+                }
+              : {}),
           },
           baseURL: baseUrl,
           secret: process.env.BETTER_AUTH_SECRET,


### PR DESCRIPTION
Enable cross-subdomain cookies and trusted proxy headers so www OAuth state/session cookies work with CMS Authentik callbacks.