### PR TITLE
Fix Authentik login on www (trusted origins + cookie baseURL)

### DIFF
--- a/src/lib/auth/trustedOrigins.ts
+++ b/src/lib/auth/trustedOrigins.ts
@@ -1,14 +1,47 @@
 // src/lib/auth/trustedOrigins.ts
-const STATIC_ORIGINS = process.env.TRUSTED_ORIGINS?.split(',').map((o) => o.trim()) || [];
+
+/** Strip trailing slashes — `https://*.itsmillertime.dev/` does not match origins. */
+function normalizeOriginEntry(value: string): string {
+  return value.trim().replace(/\/+$/, '');
+}
+
+const STATIC_ORIGINS = (process.env.TRUSTED_ORIGINS?.split(',') ?? [])
+  .map(normalizeOriginEntry)
+  .filter(Boolean);
 
 export const trustedOriginsArray: string[] = STATIC_ORIGINS;
 
-// For Better Auth — returns array from the request's origin
-export function getTrustedOrigins(request?: Request): string[] {
-  const origin = request ? new URL(request.url).origin : null;
+function forwardedOrigin(request?: Request): string | null {
+  if (!request) return null;
+  const host =
+    request.headers.get('x-forwarded-host')?.split(',')[0]?.trim() ||
+    request.headers.get('host')?.split(',')[0]?.trim();
+  if (!host) {
+    try {
+      return new URL(request.url).origin;
+    } catch {
+      return null;
+    }
+  }
+  const proto =
+    request.headers.get('x-forwarded-proto')?.split(',')[0]?.trim() ||
+    (host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https');
+  return `${proto}://${host}`;
+}
 
-  if (origin?.endsWith('.itsmillertime.dev')) {
-    return [...STATIC_ORIGINS, origin];
+// For Better Auth — returns array from the request's browser-facing origin
+export function getTrustedOrigins(request?: Request): string[] {
+  const origin = forwardedOrigin(request);
+
+  if (origin) {
+    try {
+      const host = new URL(origin).hostname;
+      if (host === 'itsmillertime.dev' || host.endsWith('.itsmillertime.dev')) {
+        return [...STATIC_ORIGINS, origin];
+      }
+    } catch {
+      // fall through
+    }
   }
 
   return STATIC_ORIGINS;

--- a/src/plugins/better-auth.ts
+++ b/src/plugins/better-auth.ts
@@ -12,8 +12,6 @@ import {
 } from '@delmaredigital/payload-better-auth';
 import { CollectionSlug } from 'payload';
 
-const baseUrl = getBaseUrl();
-
 const userLinkedCollections: { collection: CollectionSlug; field: string }[] = [
   { collection: 'sessions', field: 'user' },
   { collection: 'accounts', field: 'user' },
@@ -21,6 +19,21 @@ const userLinkedCollections: { collection: CollectionSlug; field: string }[] = [
   { collection: 'twoFactors', field: 'user' },
   { collection: 'passkeys', field: 'user' },
 ];
+
+function resolveAuthBaseUrl(): string {
+  return getBaseUrl().replace(/\/+$/, '');
+}
+
+function crossSubDomainForBaseUrl(baseUrl: string): string | null {
+  try {
+    const host = new URL(baseUrl).hostname;
+    return host === 'itsmillertime.dev' || host.endsWith('.itsmillertime.dev')
+      ? '.itsmillertime.dev'
+      : null;
+  } catch {
+    return null;
+  }
+}
 
 export function betterAuthPlugin() {
   return [
@@ -57,17 +70,9 @@ export function betterAuthPlugin() {
       autoInjectAdminComponents: true,
       autoRegisterEndpoints: true,
       createAuth: (payload) => {
-        const crossSubDomain =
-          (() => {
-            try {
-              const host = new URL(baseUrl).hostname;
-              return host === 'itsmillertime.dev' || host.endsWith('.itsmillertime.dev')
-                ? '.itsmillertime.dev'
-                : null;
-            } catch {
-              return null;
-            }
-          })();
+        // Resolve at auth-init time (not module load) so Coolify runtime env is used.
+        const baseUrl = resolveAuthBaseUrl();
+        const crossSubDomain = crossSubDomainForBaseUrl(baseUrl);
 
         return betterAuth({
           ...createBetterAuthOptions(payload),


### PR DESCRIPTION
## Summary
- Normalize `TRUSTED_ORIGINS` by stripping trailing slashes — `https://*.itsmillertime.dev/` does **not** match `https://www.itsmillertime.dev`
- Prefer `X-Forwarded-Host` when building dynamic trusted origins (www auth proxy)
- Resolve `BETTER_AUTH_URL` / cross-subdomain cookies at auth init time (Coolify runtime env), not module import time

## Why
Authentik shows “application authorized” but www never gets a session: OAuth finishes on CMS while www callback URLs/origins fail trusted-origin matching, and/or session cookies stay host-scoped to `cms.*`.

## Test plan
- [ ] Deploy CMS after merge
- [ ] In Coolify, set `TRUSTED_ORIGINS=http://localhost:5173,https://*.itsmillertime.dev` (no trailing slashes)
- [ ] Confirm `BETTER_AUTH_URL=https://cms.itsmillertime.dev`
- [ ] Login at https://www.itsmillertime.dev/account/login via Authentik
- [ ] Land on `/account/profile` logged in
- [ ] Cookies show `Domain=.itsmillertime.dev`