### PR TITLE
Route Authentik callback through www for frontend sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,14 +151,17 @@ BETTER_AUTH_URL=http://localhost:3000
 # Authentik OIDC (optional until the application/provider exists)
 # Discovery URL shape:
 # https://auth.itsmillertime.dev/application/o/<app-slug>/.well-known/openid-configuration
-# Callback URL to register in Authentik (CMS direct):
-# {BETTER_AUTH_URL}/api/auth/oauth2/callback/authentik
-# Also register frontend proxy callbacks when www initiates login:
-# https://itsmillertime.dev/api/auth/oauth2/callback/authentik
-# http://localhost:5173/api/auth/oauth2/callback/authentik
+#
+# Register BOTH redirect URIs in Authentik:
+#   https://cms.itsmillertime.dev/api/auth/oauth2/callback/authentik
+#   https://www.itsmillertime.dev/api/auth/oauth2/callback/authentik
+#
+# Production uses the www URI (from NEXT_PUBLIC_FRONTEND_URL or AUTHENTIK_REDIRECT_URI)
+# so frontend session cookies are set via the www auth proxy.
 AUTHENTIK_CLIENT_ID=
 AUTHENTIK_CLIENT_SECRET=
 AUTHENTIK_DISCOVERY_URL=
+# AUTHENTIK_REDIRECT_URI=https://www.itsmillertime.dev/api/auth/oauth2/callback/authentik
 ```
 
 ### Installation

--- a/src/lib/auth/authentik.ts
+++ b/src/lib/auth/authentik.ts
@@ -9,7 +9,32 @@ export type AuthentikOAuthConfig = {
   discoveryUrl: string;
   scopes: string[];
   pkce: boolean;
+  /**
+   * OIDC redirect_uri. Prefer the www frontend proxy callback so Set-Cookie is
+   * rewritten onto the site origin (cms-direct callbacks leave the session on cms).
+   */
+  redirectURI?: string;
 };
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+/**
+ * Where Authentik should return after consent.
+ * Prefer www `/api/auth/...` so the SvelteKit auth proxy sets the session cookie.
+ */
+export function getAuthentikRedirectURI(): string | undefined {
+  const explicit = process.env.AUTHENTIK_REDIRECT_URI?.trim();
+  if (explicit) return explicit;
+
+  const frontend = process.env.NEXT_PUBLIC_FRONTEND_URL?.trim();
+  if (frontend) {
+    return `${stripTrailingSlash(frontend)}/api/auth/oauth2/callback/authentik`;
+  }
+
+  return undefined;
+}
 
 /**
  * Returns Authentik OIDC config when env is complete; otherwise null so local
@@ -24,6 +49,8 @@ export function getAuthentikOAuthConfig(): AuthentikOAuthConfig | null {
     return null;
   }
 
+  const redirectURI = getAuthentikRedirectURI();
+
   return {
     providerId: AUTHENTIK_PROVIDER_ID,
     clientId,
@@ -31,6 +58,7 @@ export function getAuthentikOAuthConfig(): AuthentikOAuthConfig | null {
     discoveryUrl,
     scopes: ['openid', 'profile', 'email'],
     pkce: true,
+    ...(redirectURI ? { redirectURI } : {}),
     // Do not set requireIssuerValidation: Authentik often omits RFC 9207 `iss`
     // on the authorization response, which Better Auth would reject as issuer_missing.
   };


### PR DESCRIPTION
## Summary
- Set Authentik `redirectURI` from `AUTHENTIK_REDIRECT_URI` or `NEXT_PUBLIC_FRONTEND_URL` (www `/api/auth/oauth2/callback/authentik`)
- Authentik returns to www → SvelteKit auth proxy → CMS, so session `Set-Cookie` is rewritten onto the site origin

## Why
Even with `Domain=.itsmillertime.dev`, live oauth still uses `redirect_uri=https://cms.itsmillertime.dev/.../callback/authentik`. Authentik authorizes, but the session cookie is set on the CMS callback response and www never ends up logged in.

## Coolify / Authentik
1. Ensure `NEXT_PUBLIC_FRONTEND_URL=https://www.itsmillertime.dev` (already typical) **or** set:
   `AUTHENTIK_REDIRECT_URI=https://www.itsmillertime.dev/api/auth/oauth2/callback/authentik`
2. In Authentik provider redirect URIs, add:
   `https://www.itsmillertime.dev/api/auth/oauth2/callback/authentik`
   (keep the cms URI too if you want)
3. Deploy CMS, retry www login
4. Confirm authorize URL `redirect_uri` is the **www** callback (not cms)

## Test plan
- [ ] Merge + deploy CMS
- [ ] Register www callback URI in Authentik
- [ ] www login → Authentik → land on `/account/profile` logged in
- [ ] CMS admin Authentik login still works