### PR TITLE
Restore CMS Authentik callback for Payload admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,17 +151,12 @@ BETTER_AUTH_URL=http://localhost:3000
 # Authentik OIDC (optional until the application/provider exists)
 # Discovery URL shape:
 # https://auth.itsmillertime.dev/application/o/<app-slug>/.well-known/openid-configuration
-#
-# Register BOTH redirect URIs in Authentik:
+# Callback URL to register in Authentik (must match BETTER_AUTH_URL):
 #   https://cms.itsmillertime.dev/api/auth/oauth2/callback/authentik
-#   https://www.itsmillertime.dev/api/auth/oauth2/callback/authentik
-#
-# Production uses the www URI (from NEXT_PUBLIC_FRONTEND_URL or AUTHENTIK_REDIRECT_URI)
-# so frontend session cookies are set via the www auth proxy.
+# Session cookies use Domain=.itsmillertime.dev so www can reuse the session.
 AUTHENTIK_CLIENT_ID=
 AUTHENTIK_CLIENT_SECRET=
 AUTHENTIK_DISCOVERY_URL=
-# AUTHENTIK_REDIRECT_URI=https://www.itsmillertime.dev/api/auth/oauth2/callback/authentik
 ```
 
 ### Installation

--- a/src/lib/auth/authentik.ts
+++ b/src/lib/auth/authentik.ts
@@ -9,36 +9,16 @@ export type AuthentikOAuthConfig = {
   discoveryUrl: string;
   scopes: string[];
   pkce: boolean;
-  /**
-   * OIDC redirect_uri. Prefer the www frontend proxy callback so Set-Cookie is
-   * rewritten onto the site origin (cms-direct callbacks leave the session on cms).
-   */
-  redirectURI?: string;
 };
-
-function stripTrailingSlash(url: string): string {
-  return url.replace(/\/+$/, '');
-}
-
-/**
- * Where Authentik should return after consent.
- * Prefer www `/api/auth/...` so the SvelteKit auth proxy sets the session cookie.
- */
-export function getAuthentikRedirectURI(): string | undefined {
-  const explicit = process.env.AUTHENTIK_REDIRECT_URI?.trim();
-  if (explicit) return explicit;
-
-  const frontend = process.env.NEXT_PUBLIC_FRONTEND_URL?.trim();
-  if (frontend) {
-    return `${stripTrailingSlash(frontend)}/api/auth/oauth2/callback/authentik`;
-  }
-
-  return undefined;
-}
 
 /**
  * Returns Authentik OIDC config when env is complete; otherwise null so local
  * break-glass login still works before the Authentik app is created.
+ *
+ * redirect_uri is left unset so Better Auth uses BETTER_AUTH_URL
+ * (cms.itsmillertime.dev). Shared Domain=.itsmillertime.dev cookies keep the
+ * session available on www after callback. Forcing a www redirect_uri breaks
+ * Payload admin login (oauth state starts on cms, callback must match).
  */
 export function getAuthentikOAuthConfig(): AuthentikOAuthConfig | null {
   const clientId = process.env.AUTHENTIK_CLIENT_ID?.trim();
@@ -49,8 +29,6 @@ export function getAuthentikOAuthConfig(): AuthentikOAuthConfig | null {
     return null;
   }
 
-  const redirectURI = getAuthentikRedirectURI();
-
   return {
     providerId: AUTHENTIK_PROVIDER_ID,
     clientId,
@@ -58,7 +36,6 @@ export function getAuthentikOAuthConfig(): AuthentikOAuthConfig | null {
     discoveryUrl,
     scopes: ['openid', 'profile', 'email'],
     pkce: true,
-    ...(redirectURI ? { redirectURI } : {}),
     // Do not set requireIssuerValidation: Authentik often omits RFC 9207 `iss`
     // on the authorization response, which Better Auth would reject as issuer_missing.
   };


### PR DESCRIPTION
## Summary
- Reverts the forced www `redirect_uri` from #146 that broke Payload admin Authentik login
- Authentik callback stays on `cms.itsmillertime.dev` (BETTER_AUTH_URL)
- Continues to rely on `Domain=.itsmillertime.dev` session cookies so www can share the session after login

## Why
Admin starts OAuth on cms; sending the callback to www mismatches oauth state / post-login redirect and locks out `/admin`.

## Test plan
- [ ] After deploy, `POST /api/auth/sign-in/oauth2` shows `redirect_uri=https://cms.itsmillertime.dev/api/auth/oauth2/callback/authentik`
- [ ] Authentik login from `/admin` reaches Payload admin
- [ ] Break-glass still works via `/admin?local=1` if needed
- [ ] Re-test www login; if still broken, follow up with an OTT handoff (do not force www redirect_uri again)


Made with [Cursor](https://cursor.com)