### PR TITLE
Fix Authentik admin login when email is unverified

### DIFF
--- a/src/components/auth/AuthentikLoginView.tsx
+++ b/src/components/auth/AuthentikLoginView.tsx
@@ -14,10 +14,17 @@ function humanizeOAuthError(code: string): string {
   const messages: Record<string, string> = {
     access_denied: 'Access was denied by Authentik.',
     oauth_provider_not_found: 'Authentik is not configured. Please contact support.',
-    oauth_code_verification_failed: 'Could not complete Authentik sign-in. Please try again.',
+    oauth_code_verification_failed:
+      'Could not exchange the Authentik code (redirect URI / PKCE mismatch). Please try again.',
+    state_mismatch: 'Login session expired or cookies were blocked. Please try again.',
+    account_not_linked:
+      'Your email already exists but could not be linked to Authentik. Use local login once, or contact support.',
+    signup_disabled: 'No account exists for this Authentik user, and sign-up is disabled.',
     user_info_is_missing: 'Authentik did not return user information.',
     email_is_missing: 'Authentik did not share an email address.',
+    name_is_missing: 'Authentik did not share a display name.',
     unable_to_link_account: 'Could not link this Authentik account to an existing user.',
+    unable_to_create_session: 'Signed in with Authentik, but creating a session failed.',
   };
   return messages[code] ?? `Sign-in failed (${code}). Please try again or use local login.`;
 }

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -36,6 +36,10 @@ export function createBetterAuthOptions(payload?: BasePayload): Partial<BetterAu
         enabled: true,
         // Authentik is our trusted IdP — link by email on first OIDC login.
         trustedProviders: [AUTHENTIK_PROVIDER_ID],
+        // Existing Payload admins often have emailVerified=false (checkbox default).
+        // Better Auth would then refuse to link Authentik and redirect to login
+        // with ?error=account_not_linked (no session cookie) — looks like a no-op login.
+        requireLocalEmailVerified: false,
       },
     },
     emailVerification: {


### PR DESCRIPTION
## Summary
- Set `accountLinking.requireLocalEmailVerified: false` so Authentik (trusted IdP) can link to existing Payload users whose `emailVerified` checkbox is still false
- Improve OAuth error messages on the admin login view (including `account_not_linked`)

## Why
After Authentik returns `code` + `state`, Better Auth redirects to `/admin/login` with no session. That matches the default Better Auth rule: refuse implicit linking when the local user is unverified → `?error=account_not_linked` (then the login view strips the query param).

## Test plan
- [ ] Deploy CMS
- [ ] Authentik login from `/admin` — should create a session (or Access Denied if role is not admin)
- [ ] In Network, callback `Location` should no longer be `...?error=account_not_linked`
- [ ] If Access Denied, promote user role to `admin` via `/admin?local=1` and retry


Made with [Cursor](https://cursor.com)