### PR TITLE
Add frontend OAuth start for www Authentik login

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ BETTER_AUTH_URL=http://localhost:3000
 # Callback URL to register in Authentik (must match BETTER_AUTH_URL):
 #   https://cms.itsmillertime.dev/api/auth/oauth2/callback/authentik
 # Session cookies use Domain=.itsmillertime.dev so www can reuse the session.
+# Frontend (www) login starts via GET /api/frontend-oauth-start?callbackURL=...
+# so OAuth state is set on the CMS origin (same as admin), then returns to www.
 AUTHENTIK_CLIENT_ID=
 AUTHENTIK_CLIENT_SECRET=
 AUTHENTIK_DISCOVERY_URL=

--- a/src/endpoints/frontend-oauth-start.ts
+++ b/src/endpoints/frontend-oauth-start.ts
@@ -1,0 +1,111 @@
+import type { PayloadRequest } from 'payload';
+import { AUTHENTIK_PROVIDER_ID } from '../lib/auth/authentik-constants';
+import { getTrustedOrigins } from '../lib/auth/trustedOrigins';
+
+type PayloadWithAuth = PayloadRequest['payload'] & {
+  betterAuth?: {
+    api: {
+      signInWithOAuth2: (args: {
+        body: {
+          providerId: string;
+          callbackURL: string;
+          errorCallbackURL?: string;
+        };
+        headers: Headers;
+        asResponse: true;
+      }) => Promise<Response>;
+    };
+  };
+};
+
+function isAllowedReturnUrl(raw: string, request: Request): boolean {
+  try {
+    const target = new URL(raw);
+    if (target.protocol !== 'https:' && target.protocol !== 'http:') return false;
+
+    const allowed = new Set(getTrustedOrigins(request));
+    if (allowed.has(target.origin)) return true;
+
+    const host = target.hostname;
+    if (host === 'itsmillertime.dev' || host.endsWith('.itsmillertime.dev')) return true;
+    if (host === 'localhost' || host === '127.0.0.1') return true;
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start Authentik OAuth on the CMS origin (first-party cookies + cms redirect_uri),
+ * then return the browser to the frontend callbackURL after Authentik completes.
+ *
+ * Used by www login so state/session cookies are not split across www proxy + cms callback.
+ */
+export async function frontendOauthStartHandler(req: PayloadRequest): Promise<Response> {
+  if (req.method !== 'GET') {
+    return Response.json({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const requestUrl = new URL(req.url || '/', 'http://localhost');
+  const callbackURL = requestUrl.searchParams.get('callbackURL')?.trim();
+  const errorCallbackURL =
+    requestUrl.searchParams.get('errorCallbackURL')?.trim() || callbackURL;
+
+  if (!callbackURL || !isAllowedReturnUrl(callbackURL, req as unknown as Request)) {
+    return Response.json({ error: 'Invalid or missing callbackURL' }, { status: 400 });
+  }
+  if (
+    errorCallbackURL &&
+    !isAllowedReturnUrl(errorCallbackURL, req as unknown as Request)
+  ) {
+    return Response.json({ error: 'Invalid errorCallbackURL' }, { status: 400 });
+  }
+
+  const auth = (req.payload as PayloadWithAuth).betterAuth;
+  if (!auth?.api?.signInWithOAuth2) {
+    return Response.json({ error: 'Auth not initialized' }, { status: 500 });
+  }
+
+  try {
+    const response = await auth.api.signInWithOAuth2({
+      body: {
+        providerId: AUTHENTIK_PROVIDER_ID,
+        callbackURL,
+        errorCallbackURL: errorCallbackURL || callbackURL,
+      },
+      headers: req.headers,
+      asResponse: true,
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      return response;
+    }
+
+    const setCookies =
+      typeof response.headers.getSetCookie === 'function'
+        ? response.headers.getSetCookie()
+        : [];
+
+    const data = (await response.json().catch(() => null)) as {
+      url?: string;
+      redirect?: boolean;
+    } | null;
+
+    if (data?.url) {
+      const headers = new Headers({ Location: data.url });
+      for (const cookie of setCookies) {
+        headers.append('Set-Cookie', cookie);
+      }
+      return new Response(null, { status: 302, headers });
+    }
+
+    return Response.json(
+      { error: 'Failed to start Authentik sign-in' },
+      { status: 502 },
+    );
+  } catch (error) {
+    console.error('[frontend-oauth-start]', error);
+    return Response.json({ error: 'Failed to start Authentik sign-in' }, { status: 500 });
+  }
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -33,6 +33,7 @@ import { SiteMeta } from './globals/site-meta';
 import { SiteNavigation } from './globals/site-navigation';
 import { plugins } from './plugins';
 import { bggCollectionHandler } from './endpoints/bgg-collection';
+import { frontendOauthStartHandler } from './endpoints/frontend-oauth-start';
 import {
   clockifyProjectsHandler,
   clockifyTimerStartHandler,
@@ -172,6 +173,11 @@ export default buildConfig({
       method: 'post',
       handler: contactFormHandler,
       custom: { openapi: openapiContactForm },
+    },
+    {
+      path: '/frontend-oauth-start',
+      method: 'get',
+      handler: frontendOauthStartHandler,
     },
     {
       path: '/gallery-image-tracking',


### PR DESCRIPTION
## Summary
- Adds `GET /api/frontend-oauth-start` to begin Authentik OAuth on the CMS origin
- Validates `callbackURL` / `errorCallbackURL` against trusted frontend origins
- Lets www login avoid splitting OAuth state across the www auth proxy and cms callback

## Test plan
- [ ] Deploy CMS
- [ ] `GET /api/frontend-oauth-start?callbackURL=https://www.itsmillertime.dev/account/profile&errorCallbackURL=https://www.itsmillertime.dev/account/login` redirects to Authentik
- [ ] Completing Authentik lands on www profile with a session
- [ ] CMS `/admin` Authentik login still works
- [ ] Rejects callbackURL outside trusted origins


Made with [Cursor](https://cursor.com)