### PR TITLE
Release 3.24.0: CDN share URLs for media and gallery images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # cms-itsmillertime-dev
 
+## 3.24.0
+
+### Minor Changes
+
+- Add Cloudflare CDN share URLs to media and gallery-image editors
+
 ## 3.23.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-itsmillertime-dev",
-  "version": "3.23.0",
+  "version": "3.24.0",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,6 +1,7 @@
 import { RowLabel as RowLabel_d4655109717a6f5707cd0a6520a4fd9e } from '@/components/RowLabel'
 import { TwoFactorField as TwoFactorField_aa8e4427b70b37c7820895ace344eb78 } from '@delmaredigital/payload-better-auth/components'
 import { PasskeysField as PasskeysField_b43647e48ab3e028b782c335a88830d2 } from '@delmaredigital/payload-better-auth/components/passkey'
+import { CdnShareUrl as CdnShareUrl_0192fb28f6360825f5cf614f35d69a37 } from '@/components/CdnShareUrl'
 import { EXIFCell as EXIFCell_4480aec29364ed5b9b8eceaa4eff77ef } from '@/components/EXIFCell'
 import { EXIFDisplay as EXIFDisplay_6fcfec44911dfff19a45246c27579691 } from '@/components/EXIFDisplay'
 import { BlurhashField as BlurhashField_cca06512cc763e8c25c885f0d870995d } from '@/components/BlurhashField'
@@ -75,6 +76,7 @@ export const importMap = {
   "@/components/RowLabel#RowLabel": RowLabel_d4655109717a6f5707cd0a6520a4fd9e,
   "@delmaredigital/payload-better-auth/components#TwoFactorField": TwoFactorField_aa8e4427b70b37c7820895ace344eb78,
   "@delmaredigital/payload-better-auth/components/passkey#PasskeysField": PasskeysField_b43647e48ab3e028b782c335a88830d2,
+  "@/components/CdnShareUrl#CdnShareUrl": CdnShareUrl_0192fb28f6360825f5cf614f35d69a37,
   "@/components/EXIFCell#EXIFCell": EXIFCell_4480aec29364ed5b9b8eceaa4eff77ef,
   "@/components/EXIFDisplay#EXIFDisplay": EXIFDisplay_6fcfec44911dfff19a45246c27579691,
   "@/components/BlurhashField#BlurhashField": BlurhashField_cca06512cc763e8c25c885f0d870995d,

--- a/src/collections/Gallery/Image/index.ts
+++ b/src/collections/Gallery/Image/index.ts
@@ -1,6 +1,10 @@
 import { nsfwFilter } from '@/access/filters/nsfwFilter';
 import { Groups } from '@/collections/shared/groups';
-import { imageContentFields, imageTechnicalFields } from '@/collections/shared/imageFields';
+import {
+  cdnShareUrlField,
+  imageContentFields,
+  imageTechnicalFields,
+} from '@/collections/shared/imageFields';
 import { baseUploadConfig } from '@/collections/shared/uploadConfig';
 import { removeMedusaProduct } from '@/collections/Gallery/Image/hooks/commerceDelete';
 import { PayloadRequest, slugField } from 'payload';
@@ -75,6 +79,7 @@ export const GalleryImages: CollectionConfig<'gallery-images'> = {
         readOnly: true,
       },
     },
+    cdnShareUrlField,
     {
       type: 'group',
       name: 'settings',

--- a/src/collections/Media/Media.ts
+++ b/src/collections/Media/Media.ts
@@ -1,6 +1,6 @@
 import { type CollectionConfig } from 'payload';
 import { Groups } from '../shared/groups';
-import { imageContentFields, imageTechnicalFields } from '../shared/imageFields';
+import { cdnShareUrlField, imageContentFields, imageTechnicalFields } from '../shared/imageFields';
 import { baseUploadConfig } from '../shared/uploadConfig';
 import { defaultAltText } from '../shared/defaultAltText';
 import { ensureUploadPrefix } from '../shared/ensureUploadPrefix';
@@ -58,6 +58,7 @@ export const Media: CollectionConfig = {
         readOnly: true,
       },
     },
+    cdnShareUrlField,
     ...imageTechnicalFields,
     {
       type: 'tabs',

--- a/src/collections/shared/imageFields.ts
+++ b/src/collections/shared/imageFields.ts
@@ -23,6 +23,18 @@ export const imageContentFields: Field[] = [
   },
 ];
 
+/** Cloudflare CDN share URL — shown in the editor sidebar for upload collections. */
+export const cdnShareUrlField: Field = {
+  name: 'cdnShareUrl',
+  type: 'ui',
+  admin: {
+    position: 'sidebar',
+    components: {
+      Field: '@/components/CdnShareUrl#CdnShareUrl',
+    },
+  },
+};
+
 // Shared image technical fields (exif, blurhash, etc.)
 export const imageTechnicalFields: Field[] = [
   {

--- a/src/components/CdnShareUrl.module.css
+++ b/src/components/CdnShareUrl.module.css
@@ -1,0 +1,46 @@
+.field {
+  margin-bottom: var(--base);
+}
+
+.row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--theme-border-color);
+  border-radius: var(--theme-border-radius);
+  background: var(--theme-elevation-50);
+}
+
+.url {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  word-break: break-all;
+  color: var(--theme-text);
+  text-decoration: none;
+}
+
+.url:hover {
+  text-decoration: underline;
+}
+
+.copy {
+  flex-shrink: 0;
+  margin-top: 0.05rem;
+}
+
+.hint {
+  margin: 0.4rem 0 0;
+  color: var(--theme-elevation-500);
+  font-size: 0.75rem;
+}
+
+.empty {
+  margin: 0;
+  color: var(--theme-elevation-400);
+  font-size: 0.8125rem;
+  font-style: italic;
+}

--- a/src/components/CdnShareUrl.tsx
+++ b/src/components/CdnShareUrl.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { CopyToClipboard, FieldLabel, useDocumentInfo, useField } from '@payloadcms/ui';
+import { toCdnShareUrl } from '@/utilities/cdnShareUrl';
+import styles from './CdnShareUrl.module.css';
+
+export const CdnShareUrl: React.FC = () => {
+  const { collectionSlug } = useDocumentInfo();
+  const { value: filename } = useField<string | null | undefined>({ path: 'filename' });
+  const { value: fileUrl } = useField<string | null | undefined>({ path: 'url' });
+  const { value: prefix } = useField<string | null | undefined>({ path: 'prefix' });
+
+  const slug = typeof collectionSlug === 'string' ? collectionSlug : undefined;
+  const shareUrl = useMemo(
+    () => toCdnShareUrl(slug, fileUrl, filename, prefix),
+    [slug, fileUrl, filename, prefix],
+  );
+
+  return (
+    <div className={styles.field}>
+      <FieldLabel label="CDN URL" />
+      {shareUrl ? (
+        <>
+          <div className={styles.row}>
+            <a className={styles.url} href={shareUrl} rel="noreferrer" target="_blank">
+              {shareUrl}
+            </a>
+            <span className={styles.copy}>
+              <CopyToClipboard value={shareUrl} />
+            </span>
+          </div>
+          <p className={styles.hint}>Cloudflare-cached share URL for this file.</p>
+        </>
+      ) : (
+        <p className={styles.empty}>Upload a file to get a share URL.</p>
+      )}
+    </div>
+  );
+};

--- a/src/utilities/cdnShareUrl.ts
+++ b/src/utilities/cdnShareUrl.ts
@@ -1,0 +1,38 @@
+const CDN_HOSTS: Record<string, string> = {
+  media: 'media.itsmillertime.dev',
+  'gallery-images': 'gallery-images.itsmillertime.dev',
+};
+
+const CMS_URL_FALLBACK = 'https://cms.itsmillertime.dev';
+
+/**
+ * Rewrite a Payload file URL to the Cloudflare-cached CDN host.
+ *
+ * `https://cms.itsmillertime.dev/api/gallery-images/file/IMG_3213.jpg?prefix=gallery-images`
+ * → `https://gallery-images.itsmillertime.dev/IMG_3213.jpg?prefix=gallery-images`
+ */
+export function toCdnShareUrl(
+  collectionSlug: string | undefined,
+  fileUrl: string | null | undefined,
+  filename?: string | null,
+  prefix?: string | null,
+): string | null {
+  const host = collectionSlug ? CDN_HOSTS[collectionSlug] : undefined;
+  if (!host) return null;
+
+  if (fileUrl) {
+    try {
+      const parsed = new URL(fileUrl, CMS_URL_FALLBACK);
+      const name = parsed.pathname.split('/').filter(Boolean).pop();
+      if (name) {
+        return `https://${host}/${name}${parsed.search}`;
+      }
+    } catch {
+      // Fall through to filename + prefix.
+    }
+  }
+
+  if (!filename) return null;
+  const search = prefix ? `?prefix=${encodeURIComponent(prefix)}` : '';
+  return `https://${host}/${encodeURIComponent(filename)}${search}`;
+}


### PR DESCRIPTION
## Summary
- Adds a sidebar CDN share URL on media and gallery-image editors, rewritten from the CMS file API path to `media.itsmillertime.dev` / `gallery-images.itsmillertime.dev`.
- Bumps the package version to **3.24.0**.

## Test plan
- [ ] Open a gallery image and copy the sidebar CDN URL (`gallery-images.itsmillertime.dev/...`)
- [ ] Open a media item and copy the sidebar CDN URL (`media.itsmillertime.dev/...`)
- [ ] Confirm `package.json` and changelog show 3.24.0 after merge


Made with [Cursor](https://cursor.com)