### PR TITLE
Enable Better Auth API key sessions for REST clients

### DIFF
--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -126,7 +126,18 @@ export function createBetterAuthOptions(payload?: BasePayload): Partial<BetterAu
       admin(),
       twoFactor(),
       passkey(),
-      apiKey({ enableMetadata: true }),
+      apiKey({
+        enableMetadata: true,
+        // REST clients (piu, curl) send `x-api-key`. Without this, getSession()
+        // ignores the header and Payload req.user stays null — uploads 403.
+        enableSessionForAPIKeys: true,
+        // Default is 10 requests / 24h, which cannot upload a photo album.
+        rateLimit: {
+          enabled: true,
+          timeWindow: 1000 * 60 * 60,
+          maxRequests: 10_000,
+        },
+      }),
       ...(authentik
         ? [
             genericOAuth({


### PR DESCRIPTION
## Summary
- Turn on `enableSessionForAPIKeys` so `x-api-key` from REST clients (including `piu`) becomes a Payload session. Without this, `getSession()` ignores the header and uploads 403.
- Raise the API key rate limit from the default 10/day so album uploads are possible.

## Test plan
- [ ] Merge and deploy this to the environment `piu` talks to (`cms.itsmillertime.dev` is `main` — follow with a `dev` → `main` release if needed)
- [ ] In Payload admin, create an API key while logged in as an admin (Better Auth → API Keys, not MCP / webhook keys)
- [ ] `piu config`: paste that key, save — auth should succeed
- [ ] Upload one gallery image from `piu` and confirm it is not 403