### PR TITLE
Sanitize incoming EXIF for Postgres JSON

### DIFF
--- a/src/collections/Gallery/Image/index.ts
+++ b/src/collections/Gallery/Image/index.ts
@@ -21,6 +21,7 @@ import { generateEXIF } from '@/collections/shared/generateEXIF';
 import { generateBlurHash } from '@/collections/shared/generateBlurHash';
 import { defaultAltText } from '@/collections/shared/defaultAltText';
 import { ensureUploadPrefix } from '@/collections/shared/ensureUploadPrefix';
+import { sanitizeIncomingExif } from '@/collections/shared/sanitizeIncomingExif';
 import { visibilityFilter } from '@/access/filters/visibilityFilter';
 import { allowAll } from '@/access/methods/allowAll';
 import { allowedRoles } from '@/access/methods/allowedRoles';
@@ -288,7 +289,7 @@ export const GalleryImages: CollectionConfig<'gallery-images'> = {
   hooks: {
     afterChange: [generateEXIF],
     afterDelete: [removeMedusaProduct],
-    beforeChange: [ensureUploadPrefix('gallery-images')],
+    beforeChange: [ensureUploadPrefix('gallery-images'), sanitizeIncomingExif],
     beforeValidate: [defaultAltText, generateBlurHash],
   },
 };

--- a/src/collections/Media/Media.ts
+++ b/src/collections/Media/Media.ts
@@ -4,6 +4,7 @@ import { cdnShareUrlField, imageContentFields, imageTechnicalFields } from '../s
 import { baseUploadConfig } from '../shared/uploadConfig';
 import { defaultAltText } from '../shared/defaultAltText';
 import { ensureUploadPrefix } from '../shared/ensureUploadPrefix';
+import { sanitizeIncomingExif } from '../shared/sanitizeIncomingExif';
 import { generateBlurHash } from '../shared/generateBlurHash';
 import { generateEXIF } from '../shared/generateEXIF';
 import { RBAC } from '@/access/RBAC';
@@ -88,7 +89,7 @@ export const Media: CollectionConfig = {
   upload: baseUploadConfig,
   hooks: {
     afterChange: [generateEXIF],
-    beforeChange: [ensureUploadPrefix('media')],
+    beforeChange: [ensureUploadPrefix('media'), sanitizeIncomingExif],
     beforeValidate: [defaultAltText, generateBlurHash],
   },
 };

--- a/src/collections/shared/sanitizeIncomingExif.ts
+++ b/src/collections/shared/sanitizeIncomingExif.ts
@@ -1,0 +1,9 @@
+import type { CollectionBeforeChangeHook } from 'payload';
+import { sanitizeExifForStorage } from '@/utilities/sanitizeExif';
+
+/** REST/admin creates can send EXIF with IPTC null bytes that Postgres JSON rejects. */
+export const sanitizeIncomingExif: CollectionBeforeChangeHook = ({ data }) => {
+  if (!data || data.exif == null) return data;
+  data.exif = sanitizeExifForStorage(data.exif);
+  return data;
+};

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -84,51 +84,10 @@ import { safeEmailSubjectLine } from './utilities/sanitizeContactForm';
 import { ResetPasswordEmail } from '../emails/reset-password';
 import { VerifyAccountEmail } from '../emails/verify-account';
 import { trustedOriginsArray } from './lib/auth/trustedOrigins';
+import { sanitizeExifForStorage } from './utilities/sanitizeExif';
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
-
-/** Keys that commonly hold large binary/base64 blobs from ExifReader expanded output */
-const EXIF_HEAVY_KEYS = new Set([
-  'Thumbnail',
-  'thumbnail',
-  'MakerNote',
-  'makerNote',
-  'icc',
-]);
-
-/**
- * Strip binary/thumbnail payloads and null bytes so EXIF JSON stays small enough
- * for Payload admin Server Action saves (Next.js default body limit is 1MB).
- */
-function sanitizeExifForStorage(rawExif: unknown): Record<string, unknown> | null {
-  if (rawExif == null) return null;
-
-  const stripHeavy = (value: unknown): unknown => {
-    if (value == null) return value;
-    if (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer) return undefined;
-    if (ArrayBuffer.isView?.(value)) return undefined;
-    if (Array.isArray(value)) return value.map(stripHeavy).filter((v) => v !== undefined);
-    if (typeof value === 'object') {
-      const out: Record<string, unknown> = {};
-      for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-        if (EXIF_HEAVY_KEYS.has(key)) continue;
-        const cleaned = stripHeavy(child);
-        if (cleaned !== undefined) out[key] = cleaned;
-      }
-      return out;
-    }
-    return value;
-  };
-
-  try {
-    const stripped = stripHeavy(rawExif);
-    // PostgreSQL JSON rejects \u0000; XMP packets often end with it
-    return JSON.parse(JSON.stringify(stripped).replace(/\\u0000/g, ''));
-  } catch {
-    return { _error: 'failed_to_sanitize_exif' };
-  }
-}
 
 export default buildConfig({
   email: resendAdapter({

--- a/src/utilities/sanitizeExif.ts
+++ b/src/utilities/sanitizeExif.ts
@@ -1,0 +1,36 @@
+/** Keys that commonly hold large binary/base64 blobs from ExifReader expanded output */
+const EXIF_HEAVY_KEYS = new Set(['Thumbnail', 'thumbnail', 'MakerNote', 'makerNote', 'icc']);
+
+/**
+ * Strip binary/thumbnail payloads and null bytes so EXIF JSON stays small enough
+ * for Payload admin Server Action saves (Next.js default body limit is 1MB).
+ * PostgreSQL JSON/JSONB also rejects `\u0000` (IPTC ApplicationRecordVersion).
+ */
+export function sanitizeExifForStorage(rawExif: unknown): Record<string, unknown> | null {
+  if (rawExif == null) return null;
+
+  const stripHeavy = (value: unknown): unknown => {
+    if (value == null) return value;
+    if (typeof value === 'string') return value.replaceAll('\u0000', '');
+    if (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer) return undefined;
+    if (ArrayBuffer.isView?.(value)) return undefined;
+    if (Array.isArray(value)) return value.map(stripHeavy).filter((v) => v !== undefined);
+    if (typeof value === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+        if (EXIF_HEAVY_KEYS.has(key)) continue;
+        const cleaned = stripHeavy(child);
+        if (cleaned !== undefined) out[key] = cleaned;
+      }
+      return out;
+    }
+    return value;
+  };
+
+  try {
+    const stripped = stripHeavy(rawExif);
+    return JSON.parse(JSON.stringify(stripped).replace(/\\u0000/g, ''));
+  } catch {
+    return { _error: 'failed_to_sanitize_exif' };
+  }
+}


### PR DESCRIPTION
## Summary
- Strip `\u0000` and heavy binary EXIF (thumbnails, MakerNote) on **create/update**, not only in the background EXIF job.
- REST uploads from `piu` were failing with `unsupported Unicode escape sequence` because IPTC `ApplicationRecordVersion` is `"\u0000\u0004"`.

## Test plan
- [ ] Merge and deploy to the CMS `piu` talks to (`main` if that is production)
- [ ] Re-upload `IMG_5840-full-watermarked.jpg` (or any Lightroom JPEG with IPTC) via `piu`
- [ ] Confirm the gallery image row is created and EXIF is present without a 500
- [ ] Confirm a Media image create still works