### PR TITLE
Add private gallery-masters collection

### DIFF
--- a/src/collections/Gallery/Image/index.ts
+++ b/src/collections/Gallery/Image/index.ts
@@ -166,6 +166,17 @@ export const GalleryImages: CollectionConfig<'gallery-images'> = {
         description: 'Pointer to the Medusa product. Managed by the Store tab.',
       },
     },
+    {
+      name: 'master',
+      type: 'upload',
+      relationTo: 'gallery-masters',
+      label: 'Master file',
+      admin: {
+        position: 'sidebar',
+        description:
+          'Private full-resolution original (no watermark). Used for store downloads and prints. Not publicly accessible.',
+      },
+    },
     ...imageTechnicalFields,
     {
       type: 'group',

--- a/src/collections/Gallery/Master.ts
+++ b/src/collections/Gallery/Master.ts
@@ -1,0 +1,74 @@
+import { RBAC } from '@/access/RBAC';
+import { allowedRoles } from '@/access/methods/allowedRoles';
+import { Groups } from '@/collections/shared/groups';
+import { defaultAltText } from '@/collections/shared/defaultAltText';
+import { ensureUploadPrefix } from '@/collections/shared/ensureUploadPrefix';
+import { type CollectionConfig } from 'payload';
+
+/**
+ * Private full-resolution originals for gallery images (no watermark, no
+ * Payload imageSizes). Admin-only — never use `media` for this, that
+ * collection is publicly readable.
+ *
+ * Stored in the same R2 bucket under document prefix `gallery-masters/`.
+ * Do not add a public CDN host for this slug; file routes require admin.
+ */
+export const GalleryMasters: CollectionConfig<'gallery-masters'> = {
+  slug: 'gallery-masters',
+  labels: {
+    singular: 'Master',
+    plural: 'Masters',
+  },
+  admin: {
+    group: Groups.galleries,
+    description: 'Private full-resolution originals. Not publicly readable.',
+    useAsTitle: 'filename',
+    defaultColumns: ['filename', 'alt', 'updatedAt'],
+  },
+  folders: false,
+  access: {
+    read: RBAC(allowedRoles(['admin']), [], 'gallery-masters', 'read'),
+    create: RBAC(allowedRoles(['admin']), [], 'gallery-masters', 'create'),
+    update: RBAC(allowedRoles(['admin']), [], 'gallery-masters', 'update'),
+    delete: RBAC(allowedRoles(['admin']), [], 'gallery-masters', 'delete'),
+    readVersions: RBAC(allowedRoles(['admin']), [], 'gallery-masters', 'readVersions'),
+    unlock: RBAC(allowedRoles(['admin']), [], 'gallery-masters', 'unlock'),
+    admin: RBAC(allowedRoles(['admin']), [], 'gallery-masters', 'admin'),
+  },
+  upload: {
+    disableLocalStorage: true,
+    cacheTags: true,
+    focalPoint: false,
+    displayPreview: true,
+    withMetadata: true,
+    pasteURL: false,
+    mimeTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/tiff'],
+  },
+  fields: [
+    {
+      name: 'prefix',
+      type: 'text',
+      defaultValue: 'gallery-masters',
+      admin: {
+        hidden: true,
+        readOnly: true,
+      },
+    },
+    {
+      name: 'alt',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'sourceStem',
+      type: 'text',
+      admin: {
+        description: 'Local filename stem from ingest (piu).',
+      },
+    },
+  ],
+  hooks: {
+    beforeChange: [ensureUploadPrefix('gallery-masters')],
+    beforeValidate: [defaultAltText],
+  },
+};

--- a/src/components/Commerce/StorePanel.tsx
+++ b/src/components/Commerce/StorePanel.tsx
@@ -106,6 +106,8 @@ interface StatusResponse {
   adminUrl?: string | null;
   audience?: 'public' | 'private';
   privateChannelConfigured?: boolean;
+  hasMaster?: boolean;
+  masterFilename?: string | null;
   error?: string;
 }
 
@@ -253,6 +255,8 @@ export const StorePanel: React.FC = () => {
   const [audience, setAudience] = useState<'public' | 'private'>('public');
   const [privateChannelConfigured, setPrivateChannelConfigured] = useState(true);
   const [statusError, setStatusError] = useState<string | null>(null);
+  const [hasMaster, setHasMaster] = useState(false);
+  const [masterFilename, setMasterFilename] = useState<string | null>(null);
 
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [busy, setBusy] = useState(false);
@@ -284,6 +288,8 @@ export const StorePanel: React.FC = () => {
       setAdminUrl(data.adminUrl ?? null);
       setAudience(data.audience ?? 'public');
       setPrivateChannelConfigured(data.privateChannelConfigured !== false);
+      setHasMaster(data.hasMaster === true);
+      setMasterFilename(data.masterFilename ?? null);
       if (data.error) setStatusError(data.error);
     } catch (err) {
       setStatusError(err instanceof Error ? err.message : 'Failed to load store status');
@@ -459,12 +465,13 @@ export const StorePanel: React.FC = () => {
       return;
     }
     if (
-      form.offeringSetIds.length > 0 &&
       form.mode === 'create' &&
-      !form.downloadFile
+      (form.sellsDigital || form.offeringSetIds.length > 0) &&
+      !form.downloadFile &&
+      !hasMaster
     ) {
       setActiveTab('general');
-      setFormError('Upload the high-res master file — it is sent to the print service.');
+      setFormError('This image has no master file. Re-upload with piu or drop a high-res file here.');
       return;
     }
 
@@ -907,11 +914,16 @@ export const StorePanel: React.FC = () => {
                         Current: {product.downloadFilename} (leave blank to keep)
                       </p>
                     )}
+                    {!product?.downloadFilename && hasMaster && masterFilename && (
+                      <p className={styles.fileInfo}>
+                        Using attached master: {masterFilename}
+                      </p>
+                    )}
                   </>
                 )}
                 <p className={styles.hint}>
                   Used for the digital download <em>and</em> as the print file sent to the
-                  print-on-demand service. Stored in Medusa.
+                  print-on-demand service. Leave blank to use the private master attached at ingest.
                 </p>
               </div>
             </div>

--- a/src/endpoints/medusa-commerce.ts
+++ b/src/endpoints/medusa-commerce.ts
@@ -18,6 +18,7 @@ import {
   type MedusaEnv,
   type ProductSummary,
 } from '@/lib/medusa/client';
+import { readStoredUpload } from '@/utilities/readStoredUpload';
 
 /**
  * Admin-only endpoints that let the gallery-image "Store" panel drive Medusa.
@@ -34,9 +35,28 @@ interface GalleryImageDoc {
   alt?: string | null;
   url?: string | null;
   medusaProductId?: string | null;
+  master?:
+    | number
+    | {
+        id: number;
+        filename?: string | null;
+        mimeType?: string | null;
+        prefix?: string | null;
+      }
+    | null;
   sizes?: Record<string, { url?: string | null } | undefined> | null;
   settings?: { visibility?: string | null } | null;
 }
+
+interface MasterDoc {
+  id: number;
+  filename?: string | null;
+  mimeType?: string | null;
+  prefix?: string | null;
+}
+
+const MASTER_REQUIRED =
+  'This image has no master file. Re-upload with piu or drop a high-res file on the General tab.';
 
 /** Non-public images must stay off the public storefront sales channel. */
 function isPrivateImage(image: GalleryImageDoc): boolean {
@@ -140,6 +160,26 @@ async function loadImage(req: PayloadRequest, id: number): Promise<GalleryImageD
   })) as GalleryImageDoc | null;
 }
 
+function masterIdOf(image: GalleryImageDoc): number | null {
+  if (typeof image.master === 'number') return image.master;
+  if (image.master && typeof image.master === 'object' && typeof image.master.id === 'number') {
+    return image.master.id;
+  }
+  return null;
+}
+
+async function loadMaster(req: PayloadRequest, image: GalleryImageDoc): Promise<MasterDoc | null> {
+  const id = masterIdOf(image);
+  if (id == null) return null;
+  return (await req.payload.findByID({
+    collection: 'gallery-masters',
+    id,
+    depth: 0,
+    overrideAccess: true,
+    disableErrors: true,
+  })) as MasterDoc | null;
+}
+
 async function persistPointer(
   req: PayloadRequest,
   id: number,
@@ -205,16 +245,29 @@ async function resolveStorefrontImage(
   return uploadImageFromUrl(env, src, `gallery-image-${image.id}`);
 }
 
-/** Resolve the buyer's download asset (high-res, no watermark), if provided. */
+/** Resolve the buyer's download asset (high-res, no watermark). */
 async function resolveDownloadAsset(
+  req: PayloadRequest,
   env: MedusaEnv,
   image: GalleryImageDoc,
   body: Record<string, unknown>,
+  allowAttachedMaster: boolean,
 ): Promise<{ url: string; filename: string } | null> {
   const file = decodeUpload(body, 'download', `gallery-image-${image.id}-original`);
-  if (!file) return null;
-  const url = await uploadImageBuffer(env, file.bytes, file.filename, file.contentType);
-  return { url, filename: file.filename };
+  if (file) {
+    const url = await uploadImageBuffer(env, file.bytes, file.filename, file.contentType);
+    return { url, filename: file.filename };
+  }
+
+  if (!allowAttachedMaster) return null;
+
+  const master = await loadMaster(req, image);
+  if (!master?.filename) return null;
+  const bytes = await readStoredUpload(master);
+  const filename = master.filename;
+  const contentType = master.mimeType || 'application/octet-stream';
+  const url = await uploadImageBuffer(env, bytes, filename, contentType);
+  return { url, filename };
 }
 
 /** Deep-link to a product in the Medusa admin dashboard. */
@@ -292,9 +345,20 @@ export async function medusaProductStatusHandler(req: PayloadRequest): Promise<R
 
   const audience = isPrivateImage(image) ? 'private' : 'public';
   const privateChannelConfigured = Boolean(process.env.MEDUSA_PRIVATE_SALES_CHANNEL_ID);
+  const master = await loadMaster(req, image);
+  const masterInfo = {
+    hasMaster: Boolean(master?.filename),
+    masterFilename: master?.filename ?? null,
+  };
 
   if (!image.medusaProductId) {
-    return Response.json({ configured: true, linked: false, audience, privateChannelConfigured });
+    return Response.json({
+      configured: true,
+      linked: false,
+      audience,
+      privateChannelConfigured,
+      ...masterInfo,
+    });
   }
 
   try {
@@ -309,6 +373,7 @@ export async function medusaProductStatusHandler(req: PayloadRequest): Promise<R
         audience,
         privateChannelConfigured,
         staleCleared: true,
+        ...masterInfo,
       });
     }
     return Response.json({
@@ -318,6 +383,7 @@ export async function medusaProductStatusHandler(req: PayloadRequest): Promise<R
       adminUrl: adminProductUrl(product.productId),
       audience,
       privateChannelConfigured,
+      ...masterInfo,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -362,16 +428,10 @@ export async function medusaProductCreateHandler(req: PayloadRequest): Promise<R
     const env = getMedusaEnv();
     const source = (str(body.imageSource) as ImageSource) || 'gallery';
     const imageUrl = await resolveStorefrontImage(env, image, source, body);
-    const download = await resolveDownloadAsset(env, image, body);
+    const download = await resolveDownloadAsset(req, env, image, body, true);
 
-    if (plan.offeringSetIds.length > 0 && !download) {
-      return Response.json(
-        {
-          error:
-            'Upload the high-res master file (General tab) — it is sent to the print service as the print file.',
-        },
-        { status: 400 },
-      );
+    if ((plan.sellsDigital || plan.offeringSetIds.length > 0) && !download) {
+      return Response.json({ error: MASTER_REQUIRED }, { status: 400 });
     }
 
     const product: ProductSummary = await createProduct(env, {
@@ -433,17 +493,17 @@ export async function medusaProductUpdateHandler(req: PayloadRequest): Promise<R
     }
     const source = (str(body.imageSource) as ImageSource) || 'keep';
     const imageUrl = await resolveStorefrontImage(env, image, source, body);
-    const download = await resolveDownloadAsset(env, image, body);
+    const download = await resolveDownloadAsset(
+      req,
+      env,
+      image,
+      body,
+      !existing.downloadUrl,
+    );
     const downloadUrl = download?.url ?? existing.downloadUrl ?? undefined;
 
-    if (plan.offeringSetIds.length > 0 && !downloadUrl) {
-      return Response.json(
-        {
-          error:
-            'Upload the high-res master file (General tab) — it is sent to the print service as the print file.',
-        },
-        { status: 400 },
-      );
+    if ((plan.sellsDigital || plan.offeringSetIds.length > 0) && !downloadUrl) {
+      return Response.json({ error: MASTER_REQUIRED }, { status: 400 });
     }
 
     const product = await updateProduct(env, existing.productId, existing, {

--- a/src/migrations/20260817_gallery_masters.ts
+++ b/src/migrations/20260817_gallery_masters.ts
@@ -1,0 +1,94 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Private gallery master originals:
+ * - gallery_masters upload collection (no imageSizes / focal point)
+ * - gallery_images.master_id relation
+ * - lock/preference rels so admin document locking works
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "gallery_masters" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "prefix" varchar DEFAULT 'gallery-masters',
+      "alt" varchar NOT NULL,
+      "source_stem" varchar,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "url" varchar,
+      "thumbnail_u_r_l" varchar,
+      "filename" varchar,
+      "mime_type" varchar,
+      "filesize" numeric,
+      "width" numeric,
+      "height" numeric
+    );
+
+    CREATE INDEX IF NOT EXISTS "gallery_masters_updated_at_idx"
+      ON "gallery_masters" USING btree ("updated_at");
+    CREATE INDEX IF NOT EXISTS "gallery_masters_created_at_idx"
+      ON "gallery_masters" USING btree ("created_at");
+    CREATE UNIQUE INDEX IF NOT EXISTS "gallery_masters_filename_idx"
+      ON "gallery_masters" USING btree ("filename");
+
+    ALTER TABLE "gallery_images"
+      ADD COLUMN IF NOT EXISTS "master_id" integer;
+
+    DO $$ BEGIN
+      ALTER TABLE "gallery_images"
+        ADD CONSTRAINT "gallery_images_master_id_gallery_masters_id_fk"
+        FOREIGN KEY ("master_id") REFERENCES "public"."gallery_masters"("id")
+        ON DELETE set null ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "gallery_images_master_idx"
+      ON "gallery_images" USING btree ("master_id");
+
+    ALTER TABLE "payload_locked_documents_rels"
+      ADD COLUMN IF NOT EXISTS "gallery_masters_id" integer;
+
+    DO $$ BEGIN
+      ALTER TABLE "payload_locked_documents_rels"
+        ADD CONSTRAINT "payload_locked_documents_rels_gallery_masters_fk"
+        FOREIGN KEY ("gallery_masters_id") REFERENCES "public"."gallery_masters"("id")
+        ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_gallery_masters_id_idx"
+      ON "payload_locked_documents_rels" USING btree ("gallery_masters_id");
+
+    ALTER TABLE "payload_preferences_rels"
+      ADD COLUMN IF NOT EXISTS "gallery_masters_id" integer;
+
+    DO $$ BEGIN
+      ALTER TABLE "payload_preferences_rels"
+        ADD CONSTRAINT "payload_preferences_rels_gallery_masters_fk"
+        FOREIGN KEY ("gallery_masters_id") REFERENCES "public"."gallery_masters"("id")
+        ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "payload_preferences_rels_gallery_masters_id_idx"
+      ON "payload_preferences_rels" USING btree ("gallery_masters_id");
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "gallery_images" DROP CONSTRAINT IF EXISTS "gallery_images_master_id_gallery_masters_id_fk";
+    DROP INDEX IF EXISTS "gallery_images_master_idx";
+    ALTER TABLE "gallery_images" DROP COLUMN IF EXISTS "master_id";
+
+    ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_gallery_masters_fk";
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_gallery_masters_id_idx";
+    ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "gallery_masters_id";
+
+    ALTER TABLE "payload_preferences_rels" DROP CONSTRAINT IF EXISTS "payload_preferences_rels_gallery_masters_fk";
+    DROP INDEX IF EXISTS "payload_preferences_rels_gallery_masters_id_idx";
+    ALTER TABLE "payload_preferences_rels" DROP COLUMN IF EXISTS "gallery_masters_id";
+
+    DROP TABLE IF EXISTS "gallery_masters";
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -6,6 +6,7 @@ import * as migration_20260731_models_related_posts_join from './20260731_models
 import * as migration_20260731_restore_models_related_posts from './20260731_restore_models_related_posts';
 import * as migration_20260805_gallery_albums_default_sort from './20260805_gallery_albums_default_sort';
 import * as migration_20260805_upload_collection_prefixes from './20260805_upload_collection_prefixes';
+import * as migration_20260817_gallery_masters from './20260817_gallery_masters';
 
 export const migrations = [
   {
@@ -47,5 +48,10 @@ export const migrations = [
     up: migration_20260805_upload_collection_prefixes.up,
     down: migration_20260805_upload_collection_prefixes.down,
     name: '20260805_upload_collection_prefixes',
+  },
+  {
+    up: migration_20260817_gallery_masters.up,
+    down: migration_20260817_gallery_masters.down,
+    name: '20260817_gallery_masters',
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -77,6 +77,7 @@ export interface Config {
     pages: Page;
     'gallery-albums': GalleryAlbum;
     'gallery-images': GalleryImage;
+    'gallery-masters': GalleryMaster;
     'gallery-tags': GalleryTag;
     'gallery-categories': GalleryCategory;
     gardens: Garden;
@@ -132,6 +133,7 @@ export interface Config {
     pages: PagesSelect<false> | PagesSelect<true>;
     'gallery-albums': GalleryAlbumsSelect<false> | GalleryAlbumsSelect<true>;
     'gallery-images': GalleryImagesSelect<false> | GalleryImagesSelect<true>;
+    'gallery-masters': GalleryMastersSelect<false> | GalleryMastersSelect<true>;
     'gallery-tags': GalleryTagsSelect<false> | GalleryTagsSelect<true>;
     'gallery-categories': GalleryCategoriesSelect<false> | GalleryCategoriesSelect<true>;
     gardens: GardensSelect<false> | GardensSelect<true>;
@@ -789,6 +791,10 @@ export interface GalleryImage {
    * Pointer to the Medusa product. Managed by the Store tab.
    */
   medusaProductId?: string | null;
+  /**
+   * Private full-resolution original (no watermark). Used for store downloads and prints. Not publicly accessible.
+   */
+  master?: (number | null) | GalleryMaster;
   exif?:
     | {
         [k: string]: unknown;
@@ -901,6 +907,30 @@ export interface GalleryImage {
       filename?: string | null;
     };
   };
+}
+/**
+ * Private full-resolution originals. Not publicly readable.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "gallery-masters".
+ */
+export interface GalleryMaster {
+  id: number;
+  prefix?: string | null;
+  alt: string;
+  /**
+   * Local filename stem from ingest (piu).
+   */
+  sourceStem?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
 }
 /**
  * Singular dynamic page of the front end
@@ -1758,6 +1788,10 @@ export interface PayloadLockedDocument {
         value: number | GalleryImage;
       } | null)
     | ({
+        relationTo: 'gallery-masters';
+        value: number | GalleryMaster;
+      } | null)
+    | ({
         relationTo: 'gallery-tags';
         value: number | GalleryTag;
       } | null)
@@ -2220,6 +2254,7 @@ export interface GalleryImagesSelect<T extends boolean = true> {
         allowedUsers?: T;
       };
   medusaProductId?: T;
+  master?: T;
   exif?: T;
   blurhash?: T;
   tracking?:
@@ -2327,6 +2362,24 @@ export interface GalleryImagesSelect<T extends boolean = true> {
               filename?: T;
             };
       };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "gallery-masters_select".
+ */
+export interface GalleryMastersSelect<T extends boolean = true> {
+  prefix?: T;
+  alt?: T;
+  sourceStem?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2989,6 +3042,7 @@ export interface Webhook {
           | 'pages'
           | 'gallery-albums'
           | 'gallery-images'
+          | 'gallery-masters'
           | 'gallery-tags'
           | 'gallery-categories'
           | 'gardens'

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -11,6 +11,7 @@ import { resendAdapter } from '@payloadcms/email-resend';
 import { GalleryAlbums } from './collections/Gallery/Album';
 import { GalleryCategories } from './collections/Gallery/Categories';
 import { GalleryImages } from './collections/Gallery/Image';
+import { GalleryMasters } from './collections/Gallery/Master';
 import { GalleryTags } from './collections/Gallery/Tags';
 import { Gardens } from './collections/Gardens';
 import { MapMarkers } from './collections/Map';
@@ -405,6 +406,7 @@ export default buildConfig({
     Pages,
     GalleryAlbums,
     GalleryImages,
+    GalleryMasters,
     GalleryTags,
     GalleryCategories,
     Gardens,

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -119,6 +119,7 @@ export const plugins: Plugin[] = [
       'models-tags': 'tag',
       'gallery-albums': 'images',
       'gallery-images': 'image',
+      'gallery-masters': 'lock',
       'gallery-tags': 'tag',
       'gallery-categories': 'folder',
       pages: 'page',
@@ -165,6 +166,9 @@ export const plugins: Plugin[] = [
       },
       'gallery-images': {
         signedDownloads: false,
+      },
+      'gallery-masters': {
+        signedDownloads: true,
       },
     },
     bucket: process.env.CLOUDFLARE_BUCKET as string,

--- a/src/utilities/readStoredUpload.ts
+++ b/src/utilities/readStoredUpload.ts
@@ -1,0 +1,41 @@
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import path from 'path';
+
+/**
+ * Read an upload document's object from R2/S3 using its stored prefix + filename.
+ * Used when the Payload file route is admin-only (e.g. gallery-masters).
+ */
+export async function readStoredUpload(doc: {
+  filename?: string | null;
+  prefix?: string | null;
+}): Promise<Buffer> {
+  const filename = doc.filename;
+  if (!filename) {
+    throw new Error('Upload is missing a filename');
+  }
+
+  const bucket = process.env.CLOUDFLARE_BUCKET;
+  const endpoint = process.env.CLOUDFLARE_ENDPOINT;
+  const accessKey = process.env.CLOUDFLARE_ACCESS_KEY;
+  const secretKey = process.env.CLOUDFLARE_SECRET_KEY;
+  const region = process.env.CLOUDFLARE_REGION;
+  if (!bucket || !endpoint || !accessKey || !secretKey || !region) {
+    throw new Error('Cloudflare R2 env vars are missing; cannot read stored upload');
+  }
+
+  const key = path.posix.join(doc.prefix ?? '', filename);
+  const s3 = new S3Client({
+    endpoint,
+    region,
+    credentials: { accessKeyId: accessKey, secretAccessKey: secretKey },
+  });
+  const obj = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+  const chunks: Uint8Array[] = [];
+  if (!obj.Body) {
+    throw new Error(`S3 object has no body: ${key}`);
+  }
+  for await (const chunk of obj.Body as AsyncIterable<Uint8Array>) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}


### PR DESCRIPTION
## Summary
- Adds an admin-only `gallery-masters` upload collection (no image sizes, signed R2 downloads) and a `gallery-images.master` relation so clean originals are not stored on publicly readable `media`.
- Includes Postgres migration `20260817_gallery_masters` so deploy can create the table and foreign key.
- Store panel / Medusa create uses the attached master for digital downloads and prints unless a replacement file is dropped.

## Test plan
- [ ] `payload migrate` applies `20260817_gallery_masters` cleanly
- [ ] Admin can create a gallery-masters upload and attach it on a gallery image; unauthenticated GET `/api/gallery-masters/...` is denied
- [ ] Store panel lists an image with an attached master without requiring a dropzone file
- [ ] After deploy, `piu` can POST the full-clean file to `/gallery-masters` and PATCH `gallery-images.master`


Made with [Cursor](https://cursor.com)