### PR TITLE
Add gallery product-request waitlist

### DIFF
--- a/emails/product-request-admin.tsx
+++ b/emails/product-request-admin.tsx
@@ -1,0 +1,75 @@
+import { Button, Img, Link, Text } from '@react-email/components';
+import { EmailLayout, emailStyles } from './layout';
+
+export interface ProductRequestAdminEmailProps {
+  requesterName: string;
+  requesterEmail: string;
+  imageTitle: string;
+  imageId: number;
+  imageUrl?: string;
+  galleryUrl?: string;
+  cmsUrl: string;
+}
+
+export function ProductRequestAdminEmail({
+  requesterName,
+  requesterEmail,
+  imageTitle,
+  imageId,
+  imageUrl,
+  galleryUrl,
+  cmsUrl,
+}: ProductRequestAdminEmailProps) {
+  return (
+    <EmailLayout>
+      <Text style={emailStyles.heading}>Shop listing requested</Text>
+      <Text style={emailStyles.paragraph}>
+        <strong>{requesterName}</strong> ({requesterEmail}) asked to be notified when this
+        image is available to purchase.
+      </Text>
+      {imageUrl ? (
+        <Img
+          src={imageUrl}
+          alt={imageTitle}
+          width={320}
+          style={{
+            display: 'block',
+            margin: '0 0 16px',
+            maxWidth: '100%',
+            borderRadius: '6px',
+          }}
+        />
+      ) : null}
+      <Text style={emailStyles.paragraph}>
+        <strong>Image:</strong> {imageTitle} (#{imageId})
+      </Text>
+      <Button href={cmsUrl} style={emailStyles.button}>
+        Open in CMS
+      </Button>
+      {galleryUrl ? (
+        <>
+          <Text style={emailStyles.paragraph}>View on the site:</Text>
+          <Link href={galleryUrl} style={emailStyles.link}>
+            {galleryUrl}
+          </Link>
+        </>
+      ) : null}
+      <Text style={emailStyles.footer}>
+        Reply to this email to write {requesterName} directly. When you publish the product,
+        they will also get an automatic “now available” message.
+      </Text>
+    </EmailLayout>
+  );
+}
+
+ProductRequestAdminEmail.PreviewProps = {
+  requesterName: 'Alex Example',
+  requesterEmail: 'alex@example.com',
+  imageTitle: 'Sunrise over the lake',
+  imageId: 1234,
+  imageUrl: 'https://gallery-images.itsmillertime.dev/example.jpg',
+  galleryUrl: 'https://www.itsmillertime.dev/galleries/summer-2026?selected=1234',
+  cmsUrl: 'https://cms.itsmillertime.dev/admin/collections/gallery-images/1234',
+} satisfies ProductRequestAdminEmailProps;
+
+export default ProductRequestAdminEmail;

--- a/emails/product-request-available.tsx
+++ b/emails/product-request-available.tsx
@@ -1,0 +1,41 @@
+import { Text } from '@react-email/components';
+import { ActionEmailTemplate, emailStyles } from './layout';
+
+export interface ProductRequestAvailableEmailProps {
+  requesterName: string;
+  imageTitle: string;
+  galleryUrl: string;
+}
+
+export function ProductRequestAvailableEmail({
+  requesterName,
+  imageTitle,
+  galleryUrl,
+}: ProductRequestAvailableEmailProps) {
+  const greeting = requesterName ? `Hi ${requesterName},` : 'Hi,';
+
+  return (
+    <ActionEmailTemplate
+      greeting={greeting}
+      body={
+        <Text style={emailStyles.paragraph}>
+          You asked to be notified when <strong>{imageTitle}</strong> was available to
+          purchase. It is listed now — open the image and use the Prints &amp; Products
+          tab to add it to your cart.
+        </Text>
+      }
+      buttonText="View in the gallery"
+      buttonHref={galleryUrl}
+      fallbackText="If the button doesn't work, copy and paste this link into your browser:"
+      footerText="You received this because you requested this image be made available in the shop."
+    />
+  );
+}
+
+ProductRequestAvailableEmail.PreviewProps = {
+  requesterName: 'Alex',
+  imageTitle: 'Sunrise over the lake',
+  galleryUrl: 'https://www.itsmillertime.dev/galleries/summer-2026?selected=1234',
+} satisfies ProductRequestAvailableEmailProps;
+
+export default ProductRequestAvailableEmail;

--- a/src/collections/Gallery/Image/hooks/notifyProductWaitlist.ts
+++ b/src/collections/Gallery/Image/hooks/notifyProductWaitlist.ts
@@ -1,0 +1,34 @@
+import type { CollectionAfterChangeHook } from 'payload';
+import { notifyPendingProductRequests } from '@/utilities/notifyProductRequests';
+
+/**
+ * When a gallery image first gets a Medusa product pointer, email everyone
+ * waiting on that image. Republish (draft → published) does not change this
+ * field — that path is handled in the Medusa status endpoint.
+ */
+export const notifyProductWaitlist: CollectionAfterChangeHook = async ({
+  req,
+  doc,
+  previousDoc,
+  operation,
+}) => {
+  if (operation !== 'update') return doc;
+
+  const previousId =
+    typeof previousDoc?.medusaProductId === 'string' ? previousDoc.medusaProductId.trim() : '';
+  const nextId = typeof doc?.medusaProductId === 'string' ? doc.medusaProductId.trim() : '';
+
+  if (!nextId || previousId === nextId) return doc;
+
+  try {
+    await notifyPendingProductRequests(req.payload, doc.id);
+  } catch (err) {
+    req.payload.logger.error(
+      `[product-request] failed to queue waitlist emails for gallery-image ${doc.id}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  return doc;
+};

--- a/src/collections/Gallery/Image/index.ts
+++ b/src/collections/Gallery/Image/index.ts
@@ -7,6 +7,7 @@ import {
 } from '@/collections/shared/imageFields';
 import { baseUploadConfig } from '@/collections/shared/uploadConfig';
 import { removeMedusaProduct } from '@/collections/Gallery/Image/hooks/commerceDelete';
+import { notifyProductWaitlist } from '@/collections/Gallery/Image/hooks/notifyProductWaitlist';
 import { PayloadRequest, slugField } from 'payload';
 import {
   MetaDescriptionField,
@@ -292,13 +293,25 @@ export const GalleryImages: CollectionConfig<'gallery-images'> = {
                 },
               },
             },
+            {
+              name: 'productRequests',
+              type: 'join',
+              collection: 'gallery-product-requests',
+              on: 'galleryImage',
+              label: 'Purchase requests',
+              admin: {
+                description:
+                  'People who asked to be notified when this image is listed in the shop.',
+                allowCreate: false,
+              },
+            },
           ],
         },
       ],
     },
   ],
   hooks: {
-    afterChange: [generateEXIF],
+    afterChange: [generateEXIF, notifyProductWaitlist],
     afterDelete: [removeMedusaProduct],
     beforeChange: [ensureUploadPrefix('gallery-images'), sanitizeIncomingExif],
     beforeValidate: [defaultAltText, generateBlurHash],

--- a/src/collections/Gallery/ProductRequest/index.ts
+++ b/src/collections/Gallery/ProductRequest/index.ts
@@ -1,0 +1,110 @@
+import { RBAC } from '@/access/RBAC';
+import { allowedRoles } from '@/access/methods/allowedRoles';
+import { Groups } from '@/collections/shared/groups';
+import type { CollectionConfig } from 'payload';
+
+/**
+ * Waitlist of people who asked to be emailed when a gallery image is listed
+ * in the shop. Public creates go through POST /api/gallery-product-request,
+ * not the REST collection (create here is admin-only).
+ */
+export const GalleryProductRequests: CollectionConfig<'gallery-product-requests'> = {
+  slug: 'gallery-product-requests',
+  labels: {
+    singular: 'Product request',
+    plural: 'Product requests',
+  },
+  admin: {
+    group: Groups.galleries,
+    description: 'People waiting to buy a gallery image that is not listed yet.',
+    useAsTitle: 'name',
+    defaultColumns: ['galleryImage', 'name', 'email', 'status', 'createdAt'],
+  },
+  access: {
+    read: RBAC(allowedRoles(['admin']), [], 'gallery-product-requests', 'read'),
+    create: RBAC(allowedRoles(['admin']), [], 'gallery-product-requests', 'create'),
+    update: RBAC(allowedRoles(['admin']), [], 'gallery-product-requests', 'update'),
+    delete: RBAC(allowedRoles(['admin']), [], 'gallery-product-requests', 'delete'),
+    readVersions: RBAC(allowedRoles(['admin']), [], 'gallery-product-requests', 'readVersions'),
+    unlock: RBAC(allowedRoles(['admin']), [], 'gallery-product-requests', 'unlock'),
+    admin: RBAC(allowedRoles(['admin']), [], 'gallery-product-requests', 'admin'),
+  },
+  fields: [
+    {
+      name: 'galleryImage',
+      type: 'relationship',
+      relationTo: 'gallery-images',
+      required: true,
+      index: true,
+      admin: {
+        description: 'The gallery image they want listed in the shop.',
+      },
+    },
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+      maxLength: 200,
+    },
+    {
+      name: 'email',
+      type: 'email',
+      required: true,
+      index: true,
+    },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'pending',
+      index: true,
+      options: [
+        { label: 'Pending', value: 'pending' },
+        { label: 'Notified', value: 'notified' },
+        { label: 'Cancelled', value: 'cancelled' },
+      ],
+    },
+    {
+      name: 'albumSlug',
+      type: 'text',
+      maxLength: 200,
+      admin: {
+        description: 'Album slug at request time, used to deep-link the lightbox.',
+      },
+    },
+    {
+      name: 'imageTitle',
+      type: 'text',
+      maxLength: 300,
+      admin: {
+        description: 'Snapshot of the image alt/title for emails.',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'imageUrl',
+      type: 'text',
+      admin: {
+        description: 'Public thumbnail URL snapshot for emails.',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'notifiedAt',
+      type: 'date',
+      admin: {
+        date: { pickerAppearance: 'dayAndTime' },
+        readOnly: true,
+        condition: (data) => data?.status === 'notified',
+      },
+    },
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: {
+        description: 'Set when the requester was logged in.',
+      },
+    },
+  ],
+};

--- a/src/endpoints/gallery-product-request.ts
+++ b/src/endpoints/gallery-product-request.ts
@@ -1,0 +1,128 @@
+import type { PayloadRequest } from 'payload';
+import {
+  galleryImageCmsUrl,
+  galleryImageEmailSrc,
+  galleryImagePublicUrl,
+} from '../utilities/productRequestUrls';
+import { parseProductRequestBody } from '../utilities/sanitizeProductRequest';
+
+type GalleryImageDoc = {
+  id: number;
+  alt?: string | null;
+  url?: string | null;
+  filename?: string | null;
+  prefix?: string | null;
+};
+
+export async function galleryProductRequestHandler(req: PayloadRequest): Promise<Response> {
+  if (req.method !== 'POST') {
+    return Response.json({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const parseJson = req.json;
+  if (!parseJson) {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await parseJson.call(req);
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = parseProductRequestBody(body as Record<string, unknown>);
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const { name, email, galleryImageId, albumSlug } = parsed.data;
+
+  if (!process.env.CONTACT_EMAIL) {
+    return Response.json(
+      { error: 'Product request recipient is not configured' },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const image = (await req.payload.findByID({
+      collection: 'gallery-images',
+      id: galleryImageId,
+      depth: 0,
+      // Storefront already decided the visitor can see this image.
+      overrideAccess: true,
+      disableErrors: true,
+    })) as GalleryImageDoc | null;
+
+    if (!image) {
+      return Response.json({ error: 'Gallery image not found' }, { status: 404 });
+    }
+
+    const existing = await req.payload.find({
+      collection: 'gallery-product-requests',
+      where: {
+        and: [
+          { galleryImage: { equals: galleryImageId } },
+          { email: { equals: email } },
+          { status: { equals: 'pending' } },
+        ],
+      },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+    });
+
+    if (existing.docs.length > 0) {
+      return Response.json({ success: true, duplicate: true });
+    }
+
+    const imageTitle = (image.alt ?? '').trim() || `Image #${galleryImageId}`;
+    const imageUrl = galleryImageEmailSrc(image);
+    const galleryUrl = galleryImagePublicUrl(albumSlug, galleryImageId);
+    const cmsUrl = galleryImageCmsUrl(galleryImageId);
+
+    const userId =
+      req.user && req.user.collection === 'users' && typeof req.user.id === 'number'
+        ? req.user.id
+        : undefined;
+
+    await req.payload.create({
+      collection: 'gallery-product-requests',
+      overrideAccess: true,
+      data: {
+        galleryImage: galleryImageId,
+        name,
+        email,
+        status: 'pending',
+        albumSlug: albumSlug ?? undefined,
+        imageTitle,
+        imageUrl: imageUrl ?? undefined,
+        user: userId,
+      },
+    });
+
+    await req.payload.jobs.queue({
+      task: 'sendProductRequestAdminEmail',
+      input: {
+        requesterName: name,
+        requesterEmail: email,
+        imageTitle,
+        imageId: galleryImageId,
+        imageUrl: imageUrl ?? '',
+        galleryUrl: galleryUrl ?? '',
+        cmsUrl,
+      },
+      queue: 'email',
+    });
+
+    return Response.json({ success: true });
+  } catch (err) {
+    console.error('[gallery-product-request]', err);
+    return Response.json({ error: 'Failed to save request' }, { status: 500 });
+  }
+}

--- a/src/endpoints/medusa-commerce.ts
+++ b/src/endpoints/medusa-commerce.ts
@@ -19,6 +19,7 @@ import {
   type ProductSummary,
 } from '@/lib/medusa/client';
 import { readStoredUpload } from '@/utilities/readStoredUpload';
+import { notifyPendingProductRequests } from '@/utilities/notifyProductRequests';
 
 /**
  * Admin-only endpoints that let the gallery-image "Store" panel drive Medusa.
@@ -554,6 +555,17 @@ export async function medusaProductSetStatusHandler(req: PayloadRequest): Promis
     const env = getMedusaEnv();
     await setProductStatus(env, image.medusaProductId, status);
     const product = await getProduct(env, image.medusaProductId);
+    if (status === 'published') {
+      try {
+        await notifyPendingProductRequests(req.payload, id);
+      } catch (err) {
+        req.payload.logger.error(
+          `[product-request] failed to queue waitlist emails for gallery-image ${id}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
     return Response.json({ ok: true, product });
   } catch (err) {
     return logAndFail('product/status (set)', err);

--- a/src/endpoints/openapi-docs.ts
+++ b/src/endpoints/openapi-docs.ts
@@ -87,6 +87,58 @@ export const openapiContactForm = {
   },
 };
 
+export const openapiGalleryProductRequest = {
+  summary: 'Request a gallery image shop listing',
+  description:
+    'Creates a waitlist request for a gallery image that is not yet listed in the shop, and emails support. Duplicate pending requests for the same email + image are ignored.',
+  tags: ['Public'],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          required: ['name', 'email', 'galleryImageId'],
+          properties: {
+            name: { type: 'string' },
+            email: { type: 'string', format: 'email' },
+            galleryImageId: { type: 'integer', minimum: 1 },
+            albumSlug: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+  responses: {
+    '200': {
+      description: 'Request saved (or already pending)',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', example: true },
+              duplicate: { type: 'boolean' },
+            },
+          },
+        },
+      },
+    },
+    '400': {
+      description: 'Validation error',
+      content: { 'application/json': { schema: errorSchema } },
+    },
+    '404': {
+      description: 'Gallery image not found',
+      content: { 'application/json': { schema: errorSchema } },
+    },
+    '500': {
+      description: 'Save or queue failure',
+      content: { 'application/json': { schema: errorSchema } },
+    },
+  },
+};
+
 export const openapiGalleryImageTracking = {
   summary: 'Track gallery image event',
   description: 'Increments a tracking counter on a gallery image (view, download, like, etc.).',

--- a/src/jobs/productRequestEmails.ts
+++ b/src/jobs/productRequestEmails.ts
@@ -1,0 +1,159 @@
+import type { TaskHandler } from 'payload';
+import { render } from '@react-email/render';
+import React from 'react';
+import { ProductRequestAdminEmail } from '../../emails/product-request-admin';
+import { ProductRequestAvailableEmail } from '../../emails/product-request-available';
+import {
+  safeProductRequestAdminSubject,
+  safeProductRequestAvailableSubject,
+} from '../utilities/sanitizeProductRequest';
+
+export const sendProductRequestAdminEmailTask = {
+  slug: 'sendProductRequestAdminEmail',
+  retries: 3,
+  inputSchema: [
+    { name: 'requesterName', type: 'text' as const, required: true, maxLength: 200 },
+    { name: 'requesterEmail', type: 'text' as const, required: true, maxLength: 320 },
+    { name: 'imageTitle', type: 'text' as const, required: true, maxLength: 300 },
+    { name: 'imageId', type: 'number' as const, required: true },
+    { name: 'imageUrl', type: 'text' as const, required: false, maxLength: 2000 },
+    { name: 'galleryUrl', type: 'text' as const, required: false, maxLength: 2000 },
+    { name: 'cmsUrl', type: 'text' as const, required: true, maxLength: 2000 },
+  ],
+  handler: (async ({ input, req }) => {
+    try {
+      if (!process.env.RESEND_API_KEY) {
+        throw new Error('RESEND_API_KEY environment variable is not set');
+      }
+      const toEmail = process.env.CONTACT_EMAIL;
+      if (!toEmail) {
+        throw new Error('CONTACT_EMAIL environment variable is not set');
+      }
+
+      const requesterName = String(input.requesterName ?? '').trim();
+      const requesterEmail = String(input.requesterEmail ?? '').trim();
+      const imageTitle = String(input.imageTitle ?? '').trim();
+      const imageId = Number(input.imageId);
+      const cmsUrl = String(input.cmsUrl ?? '').trim();
+      const imageUrl = String(input.imageUrl ?? '').trim();
+      const galleryUrl = String(input.galleryUrl ?? '').trim();
+
+      if (!requesterName || !requesterEmail || !imageTitle || !Number.isFinite(imageId) || !cmsUrl) {
+        throw new Error('sendProductRequestAdminEmail: missing required fields');
+      }
+
+      const emailAdapter = req.payload?.email;
+      if (!emailAdapter?.sendEmail) {
+        throw new Error('sendProductRequestAdminEmail: email adapter not available');
+      }
+
+      const html = await render(
+        React.createElement(ProductRequestAdminEmail, {
+          requesterName,
+          requesterEmail,
+          imageTitle,
+          imageId,
+          imageUrl: imageUrl || undefined,
+          galleryUrl: galleryUrl || undefined,
+          cmsUrl,
+        }),
+      );
+
+      await emailAdapter.sendEmail({
+        to: toEmail,
+        replyTo: requesterEmail,
+        subject: safeProductRequestAdminSubject(imageTitle, requesterName),
+        html,
+      });
+
+      return { output: { sent: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err ?? 'Unknown error');
+      console.error('[sendProductRequestAdminEmail]', message, err);
+      throw new Error(`sendProductRequestAdminEmail failed: ${message}`);
+    }
+  }) satisfies TaskHandler<'sendProductRequestAdminEmail'>,
+};
+
+export const sendProductRequestAvailableEmailTask = {
+  slug: 'sendProductRequestAvailableEmail',
+  retries: 3,
+  inputSchema: [
+    { name: 'requestId', type: 'number' as const, required: true },
+    { name: 'requesterName', type: 'text' as const, required: true, maxLength: 200 },
+    { name: 'requesterEmail', type: 'text' as const, required: true, maxLength: 320 },
+    { name: 'imageTitle', type: 'text' as const, required: true, maxLength: 300 },
+    { name: 'galleryUrl', type: 'text' as const, required: true, maxLength: 2000 },
+  ],
+  handler: (async ({ input, req }) => {
+    try {
+      if (!process.env.RESEND_API_KEY) {
+        throw new Error('RESEND_API_KEY environment variable is not set');
+      }
+
+      const requestId = Number(input.requestId);
+      const requesterName = String(input.requesterName ?? '').trim();
+      const requesterEmail = String(input.requesterEmail ?? '').trim();
+      const imageTitle = String(input.imageTitle ?? '').trim();
+      const galleryUrl = String(input.galleryUrl ?? '').trim();
+
+      if (
+        !Number.isFinite(requestId) ||
+        !requesterName ||
+        !requesterEmail ||
+        !imageTitle ||
+        !galleryUrl
+      ) {
+        throw new Error('sendProductRequestAvailableEmail: missing required fields');
+      }
+
+      const existing = await req.payload.findByID({
+        collection: 'gallery-product-requests',
+        id: requestId,
+        depth: 0,
+        overrideAccess: true,
+        disableErrors: true,
+      });
+
+      if (!existing || existing.status !== 'pending') {
+        return { output: { sent: false, skipped: true } };
+      }
+
+      const emailAdapter = req.payload?.email;
+      if (!emailAdapter?.sendEmail) {
+        throw new Error('sendProductRequestAvailableEmail: email adapter not available');
+      }
+
+      const html = await render(
+        React.createElement(ProductRequestAvailableEmail, {
+          requesterName,
+          imageTitle,
+          galleryUrl,
+        }),
+      );
+
+      await emailAdapter.sendEmail({
+        to: requesterEmail,
+        subject: safeProductRequestAvailableSubject(imageTitle),
+        html,
+      });
+
+      await req.payload.update({
+        collection: 'gallery-product-requests',
+        id: requestId,
+        depth: 0,
+        overrideAccess: true,
+        data: {
+          status: 'notified',
+          notifiedAt: new Date().toISOString(),
+        },
+      });
+
+      return { output: { sent: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err ?? 'Unknown error');
+      console.error('[sendProductRequestAvailableEmail]', message, err);
+      throw new Error(`sendProductRequestAvailableEmail failed: ${message}`);
+    }
+  }) satisfies TaskHandler<'sendProductRequestAvailableEmail'>,
+};

--- a/src/migrations/20260818_210234_galleryProductRequests.ts
+++ b/src/migrations/20260818_210234_galleryProductRequests.ts
@@ -1,0 +1,131 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Gallery product waitlist:
+ * - gallery_product_requests collection
+ * - lock-document rel so admin document locking works
+ * - job/webhook enum values + MCP API key columns
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_gallery_product_requests_status" AS ENUM(
+        'pending',
+        'notified',
+        'cancelled'
+      );
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+
+    CREATE TABLE IF NOT EXISTS "gallery_product_requests" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "gallery_image_id" integer NOT NULL,
+      "name" varchar NOT NULL,
+      "email" varchar NOT NULL,
+      "status" "enum_gallery_product_requests_status" DEFAULT 'pending' NOT NULL,
+      "album_slug" varchar,
+      "image_title" varchar,
+      "image_url" varchar,
+      "notified_at" timestamp(3) with time zone,
+      "user_id" integer,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+    );
+
+    DO $$ BEGIN
+      ALTER TABLE "gallery_product_requests"
+        ADD CONSTRAINT "gallery_product_requests_gallery_image_id_gallery_images_id_fk"
+        FOREIGN KEY ("gallery_image_id") REFERENCES "public"."gallery_images"("id")
+        ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "gallery_product_requests"
+        ADD CONSTRAINT "gallery_product_requests_user_id_users_id_fk"
+        FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+        ON DELETE set null ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "gallery_product_requests_gallery_image_idx"
+      ON "gallery_product_requests" USING btree ("gallery_image_id");
+    CREATE INDEX IF NOT EXISTS "gallery_product_requests_email_idx"
+      ON "gallery_product_requests" USING btree ("email");
+    CREATE INDEX IF NOT EXISTS "gallery_product_requests_status_idx"
+      ON "gallery_product_requests" USING btree ("status");
+    CREATE INDEX IF NOT EXISTS "gallery_product_requests_user_idx"
+      ON "gallery_product_requests" USING btree ("user_id");
+    CREATE INDEX IF NOT EXISTS "gallery_product_requests_updated_at_idx"
+      ON "gallery_product_requests" USING btree ("updated_at");
+    CREATE INDEX IF NOT EXISTS "gallery_product_requests_created_at_idx"
+      ON "gallery_product_requests" USING btree ("created_at");
+
+    ALTER TABLE "payload_locked_documents_rels"
+      ADD COLUMN IF NOT EXISTS "gallery_product_requests_id" integer;
+
+    DO $$ BEGIN
+      ALTER TABLE "payload_locked_documents_rels"
+        ADD CONSTRAINT "payload_locked_documents_rels_gallery_product_requests_fk"
+        FOREIGN KEY ("gallery_product_requests_id") REFERENCES "public"."gallery_product_requests"("id")
+        ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_gallery_product_requests_i_idx"
+      ON "payload_locked_documents_rels" USING btree ("gallery_product_requests_id");
+
+    ALTER TABLE "payload_mcp_api_keys"
+      ADD COLUMN IF NOT EXISTS "gallery_product_requests_find" boolean DEFAULT false;
+    ALTER TABLE "payload_mcp_api_keys"
+      ADD COLUMN IF NOT EXISTS "gallery_product_requests_create" boolean DEFAULT false;
+    ALTER TABLE "payload_mcp_api_keys"
+      ADD COLUMN IF NOT EXISTS "gallery_product_requests_update" boolean DEFAULT false;
+    ALTER TABLE "payload_mcp_api_keys"
+      ADD COLUMN IF NOT EXISTS "gallery_product_requests_delete" boolean DEFAULT false;
+  `)
+
+  await db.execute(sql`
+    ALTER TYPE "public"."enum_payload_jobs_task_slug"
+      ADD VALUE IF NOT EXISTS 'sendProductRequestAdminEmail';
+  `)
+  await db.execute(sql`
+    ALTER TYPE "public"."enum_payload_jobs_task_slug"
+      ADD VALUE IF NOT EXISTS 'sendProductRequestAvailableEmail';
+  `)
+  await db.execute(sql`
+    ALTER TYPE "public"."enum_payload_jobs_log_task_slug"
+      ADD VALUE IF NOT EXISTS 'sendProductRequestAdminEmail';
+  `)
+  await db.execute(sql`
+    ALTER TYPE "public"."enum_payload_jobs_log_task_slug"
+      ADD VALUE IF NOT EXISTS 'sendProductRequestAvailableEmail';
+  `)
+  await db.execute(sql`
+    ALTER TYPE "public"."enum_webhooks_collections_collection"
+      ADD VALUE IF NOT EXISTS 'gallery-product-requests';
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "payload_locked_documents_rels"
+      DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_gallery_product_requests_fk";
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_gallery_product_requests_i_idx";
+    ALTER TABLE "payload_locked_documents_rels"
+      DROP COLUMN IF EXISTS "gallery_product_requests_id";
+
+    ALTER TABLE "payload_mcp_api_keys"
+      DROP COLUMN IF EXISTS "gallery_product_requests_find";
+    ALTER TABLE "payload_mcp_api_keys"
+      DROP COLUMN IF EXISTS "gallery_product_requests_create";
+    ALTER TABLE "payload_mcp_api_keys"
+      DROP COLUMN IF EXISTS "gallery_product_requests_update";
+    ALTER TABLE "payload_mcp_api_keys"
+      DROP COLUMN IF EXISTS "gallery_product_requests_delete";
+
+    DROP TABLE IF EXISTS "gallery_product_requests";
+    DROP TYPE IF EXISTS "public"."enum_gallery_product_requests_status";
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -7,6 +7,7 @@ import * as migration_20260731_restore_models_related_posts from './20260731_res
 import * as migration_20260805_gallery_albums_default_sort from './20260805_gallery_albums_default_sort';
 import * as migration_20260805_upload_collection_prefixes from './20260805_upload_collection_prefixes';
 import * as migration_20260817_gallery_masters from './20260817_gallery_masters';
+import * as migration_20260818_210234_galleryProductRequests from './20260818_210234_galleryProductRequests';
 
 export const migrations = [
   {
@@ -53,5 +54,10 @@ export const migrations = [
     up: migration_20260817_gallery_masters.up,
     down: migration_20260817_gallery_masters.down,
     name: '20260817_gallery_masters',
+  },
+  {
+    up: migration_20260818_210234_galleryProductRequests.up,
+    down: migration_20260818_210234_galleryProductRequests.down,
+    name: '20260818_210234_galleryProductRequests',
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -78,6 +78,7 @@ export interface Config {
     'gallery-albums': GalleryAlbum;
     'gallery-images': GalleryImage;
     'gallery-masters': GalleryMaster;
+    'gallery-product-requests': GalleryProductRequest;
     'gallery-tags': GalleryTag;
     'gallery-categories': GalleryCategory;
     gardens: Garden;
@@ -116,6 +117,9 @@ export interface Config {
       relatedPosts: 'posts';
       images: 'gallery-images';
     };
+    'gallery-images': {
+      productRequests: 'gallery-product-requests';
+    };
     kits: {
       models: 'models';
     };
@@ -134,6 +138,7 @@ export interface Config {
     'gallery-albums': GalleryAlbumsSelect<false> | GalleryAlbumsSelect<true>;
     'gallery-images': GalleryImagesSelect<false> | GalleryImagesSelect<true>;
     'gallery-masters': GalleryMastersSelect<false> | GalleryMastersSelect<true>;
+    'gallery-product-requests': GalleryProductRequestsSelect<false> | GalleryProductRequestsSelect<true>;
     'gallery-tags': GalleryTagsSelect<false> | GalleryTagsSelect<true>;
     'gallery-categories': GalleryCategoriesSelect<false> | GalleryCategoriesSelect<true>;
     gardens: GardensSelect<false> | GardensSelect<true>;
@@ -192,6 +197,8 @@ export interface Config {
       sendResetPasswordEmail: TaskSendResetPasswordEmail;
       sendVerificationEmail: TaskSendVerificationEmail;
       sendContactFormEmail: TaskSendContactFormEmail;
+      sendProductRequestAdminEmail: TaskSendProductRequestAdminEmail;
+      sendProductRequestAvailableEmail: TaskSendProductRequestAvailableEmail;
       schedulePublish: TaskSchedulePublish;
       inline: {
         input: unknown;
@@ -838,6 +845,14 @@ export interface GalleryImage {
      */
     image?: (number | null) | GalleryImage;
   };
+  /**
+   * People who asked to be notified when this image is listed in the shop.
+   */
+  productRequests?: {
+    docs?: (number | GalleryProductRequest)[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -931,6 +946,41 @@ export interface GalleryMaster {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+}
+/**
+ * People waiting to buy a gallery image that is not listed yet.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "gallery-product-requests".
+ */
+export interface GalleryProductRequest {
+  id: number;
+  /**
+   * The gallery image they want listed in the shop.
+   */
+  galleryImage: number | GalleryImage;
+  name: string;
+  email: string;
+  status: 'pending' | 'notified' | 'cancelled';
+  /**
+   * Album slug at request time, used to deep-link the lightbox.
+   */
+  albumSlug?: string | null;
+  /**
+   * Snapshot of the image alt/title for emails.
+   */
+  imageTitle?: string | null;
+  /**
+   * Public thumbnail URL snapshot for emails.
+   */
+  imageUrl?: string | null;
+  notifiedAt?: string | null;
+  /**
+   * Set when the requester was logged in.
+   */
+  user?: (number | null) | User;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * Singular dynamic page of the front end
@@ -1403,6 +1453,24 @@ export interface PayloadMcpApiKey {
      */
     delete?: boolean | null;
   };
+  galleryProductRequests?: {
+    /**
+     * Allow clients to find gallery-product-requests.
+     */
+    find?: boolean | null;
+    /**
+     * Allow clients to create gallery-product-requests.
+     */
+    create?: boolean | null;
+    /**
+     * Allow clients to update gallery-product-requests.
+     */
+    update?: boolean | null;
+    /**
+     * Allow clients to delete gallery-product-requests.
+     */
+    delete?: boolean | null;
+  };
   galleryCategories?: {
     /**
      * Allow clients to find gallery-categories.
@@ -1685,6 +1753,8 @@ export interface PayloadJob {
           | 'sendResetPasswordEmail'
           | 'sendVerificationEmail'
           | 'sendContactFormEmail'
+          | 'sendProductRequestAdminEmail'
+          | 'sendProductRequestAvailableEmail'
           | 'schedulePublish';
         taskID: string;
         input?:
@@ -1726,6 +1796,8 @@ export interface PayloadJob {
         | 'sendResetPasswordEmail'
         | 'sendVerificationEmail'
         | 'sendContactFormEmail'
+        | 'sendProductRequestAdminEmail'
+        | 'sendProductRequestAvailableEmail'
         | 'schedulePublish'
       )
     | null;
@@ -1790,6 +1862,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'gallery-masters';
         value: number | GalleryMaster;
+      } | null)
+    | ({
+        relationTo: 'gallery-product-requests';
+        value: number | GalleryProductRequest;
       } | null)
     | ({
         relationTo: 'gallery-tags';
@@ -2277,6 +2353,7 @@ export interface GalleryImagesSelect<T extends boolean = true> {
         description?: T;
         image?: T;
       };
+  productRequests?: T;
   updatedAt?: T;
   createdAt?: T;
   url?: T;
@@ -2380,6 +2457,23 @@ export interface GalleryMastersSelect<T extends boolean = true> {
   filesize?: T;
   width?: T;
   height?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "gallery-product-requests_select".
+ */
+export interface GalleryProductRequestsSelect<T extends boolean = true> {
+  galleryImage?: T;
+  name?: T;
+  email?: T;
+  status?: T;
+  albumSlug?: T;
+  imageTitle?: T;
+  imageUrl?: T;
+  notifiedAt?: T;
+  user?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2752,6 +2846,14 @@ export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
         update?: T;
         delete?: T;
       };
+  galleryProductRequests?:
+    | T
+    | {
+        find?: T;
+        create?: T;
+        update?: T;
+        delete?: T;
+      };
   galleryCategories?:
     | T
     | {
@@ -3043,6 +3145,7 @@ export interface Webhook {
           | 'gallery-albums'
           | 'gallery-images'
           | 'gallery-masters'
+          | 'gallery-product-requests'
           | 'gallery-tags'
           | 'gallery-categories'
           | 'gardens'
@@ -3287,6 +3390,36 @@ export interface TaskSendContactFormEmail {
     senderName: string;
     senderEmail: string;
     message: string;
+  };
+  output?: unknown;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TaskSendProductRequestAdminEmail".
+ */
+export interface TaskSendProductRequestAdminEmail {
+  input: {
+    requesterName: string;
+    requesterEmail: string;
+    imageTitle: string;
+    imageId: number;
+    imageUrl?: string | null;
+    galleryUrl?: string | null;
+    cmsUrl: string;
+  };
+  output?: unknown;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TaskSendProductRequestAvailableEmail".
+ */
+export interface TaskSendProductRequestAvailableEmail {
+  input: {
+    requestId: number;
+    requesterName: string;
+    requesterEmail: string;
+    imageTitle: string;
+    galleryUrl: string;
   };
   output?: unknown;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -12,6 +12,7 @@ import { GalleryAlbums } from './collections/Gallery/Album';
 import { GalleryCategories } from './collections/Gallery/Categories';
 import { GalleryImages } from './collections/Gallery/Image';
 import { GalleryMasters } from './collections/Gallery/Master';
+import { GalleryProductRequests } from './collections/Gallery/ProductRequest';
 import { GalleryTags } from './collections/Gallery/Tags';
 import { Gardens } from './collections/Gardens';
 import { MapMarkers } from './collections/Map';
@@ -42,6 +43,7 @@ import {
   clockifyTimerStopHandler,
 } from './endpoints/clockify-timer';
 import { contactFormHandler } from './endpoints/contact-form';
+import { galleryProductRequestHandler } from './endpoints/gallery-product-request';
 import { galleryImageTrackingHandler } from './endpoints/gallery-image-tracking';
 import { lastfmNowPlayingHandler } from './endpoints/lastfm-now-playing';
 import {
@@ -63,6 +65,7 @@ import {
   openapiClockifyTimerStart,
   openapiClockifyTimerStop,
   openapiContactForm,
+  openapiGalleryProductRequest,
   openapiGalleryImageTracking,
   openapiHealth,
   openapiLastfmNowPlaying,
@@ -84,6 +87,10 @@ import { ContactFormEmail } from '../emails/contact-form';
 import { safeEmailSubjectLine } from './utilities/sanitizeContactForm';
 import { ResetPasswordEmail } from '../emails/reset-password';
 import { VerifyAccountEmail } from '../emails/verify-account';
+import {
+  sendProductRequestAdminEmailTask,
+  sendProductRequestAvailableEmailTask,
+} from './jobs/productRequestEmails';
 import { trustedOriginsArray } from './lib/auth/trustedOrigins';
 import { sanitizeExifForStorage } from './utilities/sanitizeExif';
 
@@ -133,6 +140,12 @@ export default buildConfig({
       method: 'post',
       handler: contactFormHandler,
       custom: { openapi: openapiContactForm },
+    },
+    {
+      path: '/gallery-product-request',
+      method: 'post',
+      handler: galleryProductRequestHandler,
+      custom: { openapi: openapiGalleryProductRequest },
     },
     {
       path: '/frontend-oauth-start',
@@ -366,6 +379,7 @@ export default buildConfig({
     GalleryAlbums,
     GalleryImages,
     GalleryMasters,
+    GalleryProductRequests,
     GalleryTags,
     GalleryCategories,
     Gardens,
@@ -805,6 +819,8 @@ export default buildConfig({
           }
         },
       },
+      sendProductRequestAdminEmailTask,
+      sendProductRequestAvailableEmailTask,
     ],
     autoRun: [
       {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -121,6 +121,7 @@ export const plugins: Plugin[] = [
       'gallery-images': 'image',
       'gallery-masters': 'lock',
       'gallery-tags': 'tag',
+      'gallery-product-requests': 'bell',
       'gallery-categories': 'folder',
       pages: 'page',
       users: 'user',

--- a/src/plugins/mcp.ts
+++ b/src/plugins/mcp.ts
@@ -18,6 +18,10 @@ export function mcpPlugin() {
         enabled: true,
         description: 'Gallery Tags',
       },
+      'gallery-product-requests': {
+        enabled: true,
+        description: 'Gallery product waitlist requests',
+      },
       'gallery-categories': {
         enabled: true,
         description: 'Gallery Categories',

--- a/src/utilities/notifyProductRequests.ts
+++ b/src/utilities/notifyProductRequests.ts
@@ -1,0 +1,49 @@
+import type { Payload } from 'payload';
+import { frontendBaseUrl, galleryImagePublicUrl } from './productRequestUrls';
+
+/**
+ * Queue a "now available" email for every pending request on this image.
+ * Safe to call more than once: the job no-ops if the row is no longer pending.
+ */
+export async function notifyPendingProductRequests(
+  payload: Payload,
+  galleryImageId: number,
+): Promise<void> {
+  let page = 1;
+  const limit = 50;
+  let hasMore = true;
+
+  while (hasMore) {
+    const result = await payload.find({
+      collection: 'gallery-product-requests',
+      where: {
+        and: [
+          { galleryImage: { equals: galleryImageId } },
+          { status: { equals: 'pending' } },
+        ],
+      },
+      limit,
+      page,
+      depth: 0,
+      overrideAccess: true,
+    });
+
+    for (const doc of result.docs) {
+      const imageTitle = (doc.imageTitle ?? '').trim() || 'a gallery image';
+      await payload.jobs.queue({
+        task: 'sendProductRequestAvailableEmail',
+        input: {
+          requestId: doc.id,
+          requesterName: doc.name,
+          requesterEmail: doc.email,
+          imageTitle,
+          galleryUrl: galleryImagePublicUrl(doc.albumSlug, galleryImageId) ?? frontendBaseUrl(),
+        },
+        queue: 'email',
+      });
+    }
+
+    hasMore = Boolean(result.hasNextPage);
+    page += 1;
+  }
+}

--- a/src/utilities/productRequestUrls.ts
+++ b/src/utilities/productRequestUrls.ts
@@ -1,0 +1,36 @@
+import { toCdnShareUrl } from './cdnShareUrl';
+
+const FRONTEND_FALLBACK = 'https://www.itsmillertime.dev';
+const CMS_FALLBACK = 'https://cms.itsmillertime.dev';
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+export function frontendBaseUrl(): string {
+  return stripTrailingSlash(process.env.NEXT_PUBLIC_FRONTEND_URL || FRONTEND_FALLBACK);
+}
+
+export function cmsBaseUrl(): string {
+  return stripTrailingSlash(process.env.NEXT_PUBLIC_SERVER_URL || CMS_FALLBACK);
+}
+
+export function galleryImagePublicUrl(
+  albumSlug: string | null | undefined,
+  imageId: number,
+): string | null {
+  if (!albumSlug) return null;
+  return `${frontendBaseUrl()}/galleries/${encodeURIComponent(albumSlug)}?selected=${imageId}`;
+}
+
+export function galleryImageCmsUrl(imageId: number): string {
+  return `${cmsBaseUrl()}/admin/collections/gallery-images/${imageId}`;
+}
+
+export function galleryImageEmailSrc(image: {
+  url?: string | null;
+  filename?: string | null;
+  prefix?: string | null;
+}): string | null {
+  return toCdnShareUrl('gallery-images', image.url, image.filename, image.prefix);
+}

--- a/src/utilities/sanitizeProductRequest.ts
+++ b/src/utilities/sanitizeProductRequest.ts
@@ -1,0 +1,94 @@
+import sanitizeHtml from 'sanitize-html';
+import { z } from 'zod';
+
+const MAX_NAME = 200;
+const MAX_EMAIL = 320;
+const MAX_SLUG = 200;
+
+const NO_HTML = {
+  allowedTags: [] as string[],
+  allowedAttributes: {},
+} as const satisfies Parameters<typeof sanitizeHtml>[1];
+
+function stripHtmlInjection(s: string): string {
+  return sanitizeHtml(s, NO_HTML);
+}
+
+function stripControlsSingleLine(s: string): string {
+  return s
+    .replace(/\u0000/g, '')
+    .replace(/[\u0001-\u001F\u007F]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export type ProductRequestFields = {
+  name: string;
+  email: string;
+  galleryImageId: number;
+  albumSlug: string | null;
+};
+
+const productRequestSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(MAX_NAME, 'Name is too long'),
+  email: z
+    .string()
+    .min(1, 'Email is required')
+    .max(MAX_EMAIL, 'Email is too long')
+    .email('Invalid email address')
+    .refine((s) => !/[\r\n<>]/.test(s), 'Invalid email address'),
+  galleryImageId: z.number().int().positive('Invalid gallery image id'),
+  albumSlug: z
+    .string()
+    .max(MAX_SLUG, 'Album slug is too long')
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Invalid album slug')
+    .nullable(),
+});
+
+export type ProductRequestParseResult =
+  | { success: true; data: ProductRequestFields }
+  | { success: false; error: string };
+
+export function parseProductRequestBody(raw: {
+  name?: unknown;
+  email?: unknown;
+  galleryImageId?: unknown;
+  albumSlug?: unknown;
+}): ProductRequestParseResult {
+  const nameIn = typeof raw.name === 'string' ? raw.name : '';
+  const emailIn = typeof raw.email === 'string' ? raw.email : '';
+  const slugIn = typeof raw.albumSlug === 'string' ? raw.albumSlug : '';
+
+  const name = stripControlsSingleLine(stripHtmlInjection(nameIn)).slice(0, MAX_NAME);
+  const email = stripHtmlInjection(emailIn.trim()).toLowerCase().slice(0, MAX_EMAIL);
+  const albumSlugRaw = stripControlsSingleLine(stripHtmlInjection(slugIn))
+    .toLowerCase()
+    .slice(0, MAX_SLUG);
+
+  const galleryImageId = Number(raw.galleryImageId);
+
+  const parsed = productRequestSchema.safeParse({
+    name,
+    email,
+    galleryImageId,
+    albumSlug: albumSlugRaw.length > 0 ? albumSlugRaw : null,
+  });
+
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    return { success: false, error: first?.message ?? 'Invalid input' };
+  }
+
+  return { success: true, data: parsed.data };
+}
+
+export function safeProductRequestAdminSubject(imageTitle: string, requesterName: string): string {
+  const title = imageTitle.replace(/[\r\n\u0000]/g, ' ').trim() || 'gallery image';
+  const name = requesterName.replace(/[\r\n\u0000]/g, ' ').trim() || 'someone';
+  return `Shop request: ${title} from ${name}`.slice(0, 998);
+}
+
+export function safeProductRequestAvailableSubject(imageTitle: string): string {
+  const title = imageTitle.replace(/[\r\n\u0000]/g, ' ').trim() || 'A gallery image';
+  return `${title} is now available to purchase`.slice(0, 998);
+}


### PR DESCRIPTION
## Summary
- Adds a `gallery-product-requests` collection so people can ask to be emailed when an unlisted gallery image is put in the shop.
- Public submissions go through `POST /api/gallery-product-request` (sanitized, deduped). Support gets a Resend email with Reply-To set to the requester.
- When a Medusa product is first linked or published, pending requesters get a “now available” email and the request is marked notified.

## Test plan
- [ ] Confirm **Product requests** appears under Galleries in the admin UI.
- [ ] Create a request via `POST /api/gallery-product-request` with name, email, and a real `galleryImageId`; confirm the CMS row and support email.
- [ ] Submit the same email + image again and confirm `duplicate: true` with no second pending row.
- [ ] On the image Store tab, confirm the purchase-requests join lists the waitlist.
- [ ] List or publish the image’s Medusa product and confirm the requester gets the available email and the row status becomes **Notified**.


Made with [Cursor](https://cursor.com)