### PR TITLE
Hand www a session ticket after Authentik so phone logins stick

### DIFF
--- a/src/endpoints/frontend-oauth-continue.ts
+++ b/src/endpoints/frontend-oauth-continue.ts
@@ -1,0 +1,92 @@
+import type { PayloadRequest } from 'payload';
+import {
+  cmsPublicOrigin,
+  isAllowedReturnUrl,
+} from '../lib/auth/frontend-oauth-urls';
+import {
+  createSessionTicket,
+  readSessionCookie,
+} from '../lib/auth/frontend-oauth-ticket';
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function continuePage(dest: string, message: string): Response {
+  const safeDest = escapeHtml(dest);
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="referrer" content="no-referrer" />
+  <meta http-equiv="refresh" content="0;url=${safeDest}" />
+  <title>Signing you in…</title>
+  <style>
+    body { font-family: system-ui, sans-serif; display: flex; justify-content: center; padding: 3rem; }
+    a { color: inherit; }
+  </style>
+</head>
+<body>
+  <p>${escapeHtml(message)} <a href="${safeDest}">Continue</a></p>
+  <script>location.replace(${JSON.stringify(dest)});</script>
+</body>
+</html>`;
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'Referrer-Policy': 'no-referrer',
+    },
+  });
+}
+
+/**
+ * Same-origin landing after Authentik so the CMS session cookie is committed,
+ * then redirect to the frontend with a short-lived ticket. www exchanges that
+ * ticket and sets a first-party session cookie (mobile Chrome/Safari drop
+ * Domain= cookies set on a cross-origin 302 from cms → www).
+ */
+export async function frontendOauthContinueHandler(req: PayloadRequest): Promise<Response> {
+  if (req.method !== 'GET') {
+    return Response.json({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const requestUrl = new URL(req.url || '/', cmsPublicOrigin());
+  const to = requestUrl.searchParams.get('to')?.trim();
+  const errorUrl = requestUrl.searchParams.get('error')?.trim();
+  const request = req as unknown as Request;
+
+  if (!to || !isAllowedReturnUrl(to, request)) {
+    return Response.json({ error: 'Invalid destination' }, { status: 400 });
+  }
+  if (errorUrl && !isAllowedReturnUrl(errorUrl, request)) {
+    return Response.json({ error: 'Invalid error destination' }, { status: 400 });
+  }
+
+  const failDest = errorUrl || to;
+  const sessionCookie = readSessionCookie(req.headers.get('cookie'));
+  if (!sessionCookie) {
+    const dest = new URL(failDest);
+    dest.searchParams.set('error', 'unable_to_create_session');
+    return continuePage(dest.toString(), 'Sign-in did not complete.');
+  }
+
+  try {
+    const ticket = createSessionTicket(sessionCookie);
+    const dest = new URL(to);
+    dest.searchParams.set('ticket', ticket);
+    return continuePage(dest.toString(), 'Signing you in…');
+  } catch (error) {
+    console.error('[frontend-oauth-continue]', error);
+    const dest = new URL(failDest);
+    dest.searchParams.set('error', 'unable_to_create_session');
+    return continuePage(dest.toString(), 'Sign-in did not complete.');
+  }
+}

--- a/src/endpoints/frontend-oauth-exchange.ts
+++ b/src/endpoints/frontend-oauth-exchange.ts
@@ -1,0 +1,43 @@
+import type { PayloadRequest } from 'payload';
+import { openSessionTicket } from '../lib/auth/frontend-oauth-ticket';
+
+/**
+ * www POSTs the continue-page ticket and receives the session cookie to set
+ * first-party on the site origin. Ticket TTL is 90s.
+ */
+export async function frontendOauthExchangeHandler(req: PayloadRequest): Promise<Response> {
+  if (req.method !== 'POST') {
+    return Response.json({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const parseJson = req.json;
+  if (!parseJson) {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await parseJson.call(req);
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const ticket =
+    body && typeof body === 'object' && !Array.isArray(body)
+      ? (body as { ticket?: unknown }).ticket
+      : undefined;
+  if (typeof ticket !== 'string' || !ticket) {
+    return Response.json({ error: 'Missing ticket' }, { status: 400 });
+  }
+
+  const payload = openSessionTicket(ticket);
+  if (!payload) {
+    return Response.json({ error: 'Invalid or expired ticket' }, { status: 400 });
+  }
+
+  return Response.json({
+    name: payload.name,
+    value: payload.value,
+    maxAge: 60 * 60 * 24 * 30,
+  });
+}

--- a/src/endpoints/frontend-oauth-start.ts
+++ b/src/endpoints/frontend-oauth-start.ts
@@ -1,6 +1,10 @@
 import type { PayloadRequest } from 'payload';
 import { AUTHENTIK_PROVIDER_ID } from '../lib/auth/authentik-constants';
-import { getTrustedOrigins } from '../lib/auth/trustedOrigins';
+import {
+  cmsPublicOrigin,
+  handoffCallbackURL,
+  isAllowedReturnUrl,
+} from '../lib/auth/frontend-oauth-urls';
 
 type PayloadWithAuth = PayloadRequest['payload'] & {
   betterAuth?: {
@@ -18,29 +22,10 @@ type PayloadWithAuth = PayloadRequest['payload'] & {
   };
 };
 
-function isAllowedReturnUrl(raw: string, request: Request): boolean {
-  try {
-    const target = new URL(raw);
-    if (target.protocol !== 'https:' && target.protocol !== 'http:') return false;
-
-    const allowed = new Set(getTrustedOrigins(request));
-    if (allowed.has(target.origin)) return true;
-
-    const host = target.hostname;
-    if (host === 'itsmillertime.dev' || host.endsWith('.itsmillertime.dev')) return true;
-    if (host === 'localhost' || host === '127.0.0.1') return true;
-
-    return false;
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Start Authentik OAuth on the CMS origin (first-party cookies + cms redirect_uri),
- * then return the browser to the frontend callbackURL after Authentik completes.
- *
- * Used by www login so state/session cookies are not split across www proxy + cms callback.
+ * then return the browser to the frontend via /api/frontend-oauth-continue so
+ * the session cookie is committed on CMS before leaving for www.
  */
 export async function frontendOauthStartHandler(req: PayloadRequest): Promise<Response> {
   if (req.method !== 'GET') {
@@ -51,13 +36,14 @@ export async function frontendOauthStartHandler(req: PayloadRequest): Promise<Re
   const callbackURL = requestUrl.searchParams.get('callbackURL')?.trim();
   const errorCallbackURL =
     requestUrl.searchParams.get('errorCallbackURL')?.trim() || callbackURL;
+  const request = req as unknown as Request;
 
-  if (!callbackURL || !isAllowedReturnUrl(callbackURL, req as unknown as Request)) {
+  if (!callbackURL || !isAllowedReturnUrl(callbackURL, request)) {
     return Response.json({ error: 'Invalid or missing callbackURL' }, { status: 400 });
   }
   if (
     errorCallbackURL &&
-    !isAllowedReturnUrl(errorCallbackURL, req as unknown as Request)
+    !isAllowedReturnUrl(errorCallbackURL, request)
   ) {
     return Response.json({ error: 'Invalid errorCallbackURL' }, { status: 400 });
   }
@@ -67,11 +53,17 @@ export async function frontendOauthStartHandler(req: PayloadRequest): Promise<Re
     return Response.json({ error: 'Auth not initialized' }, { status: 500 });
   }
 
+  const oauthCallbackURL = handoffCallbackURL(
+    callbackURL,
+    cmsPublicOrigin(),
+    errorCallbackURL || callbackURL,
+  );
+
   try {
     const response = await auth.api.signInWithOAuth2({
       body: {
         providerId: AUTHENTIK_PROVIDER_ID,
-        callbackURL,
+        callbackURL: oauthCallbackURL,
         errorCallbackURL: errorCallbackURL || callbackURL,
       },
       headers: req.headers,

--- a/src/lib/auth/authentik.ts
+++ b/src/lib/auth/authentik.ts
@@ -16,9 +16,10 @@ export type AuthentikOAuthConfig = {
  * break-glass login still works before the Authentik app is created.
  *
  * redirect_uri is left unset so Better Auth uses BETTER_AUTH_URL
- * (cms.itsmillertime.dev). Shared Domain=.itsmillertime.dev cookies keep the
- * session available on www after callback. Forcing a www redirect_uri breaks
- * Payload admin login (oauth state starts on cms, callback must match).
+ * (cms.itsmillertime.dev). www login then lands on /api/frontend-oauth-continue
+ * (same origin) and exchanges a short-lived ticket so www can set a first-party
+ * session cookie — mobile Chrome/Safari drop Domain=.itsmillertime.dev cookies
+ * on the cms → www 302. Forcing a www redirect_uri breaks Payload admin login.
  */
 export function getAuthentikOAuthConfig(): AuthentikOAuthConfig | null {
   const clientId = process.env.AUTHENTIK_CLIENT_ID?.trim();

--- a/src/lib/auth/frontend-oauth-ticket.ts
+++ b/src/lib/auth/frontend-oauth-ticket.ts
@@ -1,0 +1,72 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+
+const TICKET_TTL_MS = 90_000;
+const VERSION = 1;
+const SESSION_COOKIE_NAME = /^(?:__Secure-)?better-auth\.session_token$/;
+
+export type SessionTicketPayload = {
+  v: number;
+  exp: number;
+  name: string;
+  value: string;
+};
+
+function keyFromSecret(): Buffer {
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) {
+    throw new Error('BETTER_AUTH_SECRET is not set');
+  }
+  return createHash('sha256').update(secret).digest();
+}
+
+export function readSessionCookie(
+  cookieHeader: string | null | undefined,
+): { name: string; value: string } | null {
+  if (!cookieHeader) return null;
+  const match = /(?:^|;\s*)((?:__Secure-)?better-auth\.session_token)=([^;]*)/.exec(
+    cookieHeader,
+  );
+  if (!match?.[1] || match[2] === undefined || match[2] === '') return null;
+  return { name: match[1], value: match[2] };
+}
+
+export function createSessionTicket(cookie: { name: string; value: string }): string {
+  if (!SESSION_COOKIE_NAME.test(cookie.name) || !cookie.value) {
+    throw new Error('Invalid session cookie');
+  }
+
+  const payload: SessionTicketPayload = {
+    v: VERSION,
+    exp: Date.now() + TICKET_TTL_MS,
+    name: cookie.name,
+    value: cookie.value,
+  };
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', keyFromSecret(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(payload), 'utf8'),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, ciphertext]).toString('base64url');
+}
+
+export function openSessionTicket(ticket: string): SessionTicketPayload | null {
+  try {
+    const buf = Buffer.from(ticket, 'base64url');
+    if (buf.length < 12 + 16 + 1) return null;
+    const iv = buf.subarray(0, 12);
+    const tag = buf.subarray(12, 28);
+    const ciphertext = buf.subarray(28);
+    const decipher = createDecipheriv('aes-256-gcm', keyFromSecret(), iv);
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    const payload = JSON.parse(plaintext.toString('utf8')) as SessionTicketPayload;
+    if (payload.v !== VERSION) return null;
+    if (typeof payload.exp !== 'number' || Date.now() > payload.exp) return null;
+    if (!SESSION_COOKIE_NAME.test(payload.name) || !payload.value) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/auth/frontend-oauth-urls.ts
+++ b/src/lib/auth/frontend-oauth-urls.ts
@@ -1,0 +1,47 @@
+import { getTrustedOrigins } from './trustedOrigins';
+import { getBaseUrl } from './getBaseUrl';
+
+export function isAllowedReturnUrl(raw: string, request: Request): boolean {
+  try {
+    const target = new URL(raw);
+    if (target.protocol !== 'https:' && target.protocol !== 'http:') return false;
+
+    const allowed = new Set(getTrustedOrigins(request));
+    if (allowed.has(target.origin)) return true;
+
+    const host = target.hostname;
+    if (host === 'itsmillertime.dev' || host.endsWith('.itsmillertime.dev')) return true;
+    if (host === 'localhost' || host === '127.0.0.1') return true;
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/** Public CMS origin (BETTER_AUTH_URL). Do not use req.url — proxy internals are private. */
+export function cmsPublicOrigin(): string {
+  return getBaseUrl().replace(/\/+$/, '');
+}
+
+/**
+ * After Authentik, Better Auth 302s to callbackURL with Set-Cookie.
+ * If that Location is another origin (www), mobile Chrome/Safari often drop the cookie.
+ * Stay on CMS first so the session cookie is committed, then hand off.
+ */
+export function handoffCallbackURL(
+  frontendCallbackURL: string,
+  cmsOrigin: string,
+  errorCallbackURL?: string,
+): string {
+  const frontend = new URL(frontendCallbackURL);
+  const cms = new URL(cmsOrigin);
+  if (frontend.origin === cms.origin) return frontendCallbackURL;
+
+  const continueUrl = new URL('/api/frontend-oauth-continue', cms.origin);
+  continueUrl.searchParams.set('to', frontendCallbackURL);
+  if (errorCallbackURL) {
+    continueUrl.searchParams.set('error', errorCallbackURL);
+  }
+  return continueUrl.toString();
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -35,6 +35,8 @@ import { SiteMeta } from './globals/site-meta';
 import { SiteNavigation } from './globals/site-navigation';
 import { plugins } from './plugins';
 import { bggCollectionHandler } from './endpoints/bgg-collection';
+import { frontendOauthContinueHandler } from './endpoints/frontend-oauth-continue';
+import { frontendOauthExchangeHandler } from './endpoints/frontend-oauth-exchange';
 import { frontendOauthStartHandler } from './endpoints/frontend-oauth-start';
 import {
   clockifyProjectsHandler,
@@ -151,6 +153,16 @@ export default buildConfig({
       path: '/frontend-oauth-start',
       method: 'get',
       handler: frontendOauthStartHandler,
+    },
+    {
+      path: '/frontend-oauth-continue',
+      method: 'get',
+      handler: frontendOauthContinueHandler,
+    },
+    {
+      path: '/frontend-oauth-exchange',
+      method: 'post',
+      handler: frontendOauthExchangeHandler,
     },
     {
       path: '/gallery-image-tracking',


### PR DESCRIPTION
## Summary
- After Authentik, stay on CMS (`/api/frontend-oauth-continue`) so the session cookie is committed, then send www a 90-second encrypted ticket instead of a cross-origin 302.
- `/api/frontend-oauth-exchange` lets www set the session cookie first-party (mobile Chrome drops the cookie on the cms → www redirect).
- Pairs with www PR https://github.com/ChristopherLMiller/www-itsmillertime-dev/pull/117

## Test plan
- [ ] Deploy this with www v0.28.1
- [ ] On Android Chrome, Authentik login lands on www `/account/profile` as logged in
- [ ] Payload admin Authentik login on cms still works
- [ ] Invalid/expired ticket is rejected


Made with [Cursor](https://cursor.com)