### PR TITLE
Build Authentik redirect_uri from the www host

### DIFF
--- a/src/lib/auth/authentik.ts
+++ b/src/lib/auth/authentik.ts
@@ -15,11 +15,10 @@ export type AuthentikOAuthConfig = {
  * Returns Authentik OIDC config when env is complete; otherwise null so local
  * break-glass login still works before the Authentik app is created.
  *
- * redirect_uri is left unset so Better Auth uses BETTER_AUTH_URL
- * (cms.itsmillertime.dev). www login then lands on /api/frontend-oauth-continue
- * (same origin) and exchanges a short-lived ticket so www can set a first-party
- * session cookie — mobile Chrome/Safari drop Domain=.itsmillertime.dev cookies
- * on the cms → www 302. Forcing a www redirect_uri breaks Payload admin login.
+ * redirect_uri is left unset so Better Auth builds it from the request base URL.
+ * www login proxies /api/auth with X-Forwarded-Host=www (dynamic baseURL), so
+ * Authentik returns to www. Admin login on cms has no www forwarded host, so
+ * the callback stays on cms.
  */
 export function getAuthentikOAuthConfig(): AuthentikOAuthConfig | null {
   const clientId = process.env.AUTHENTIK_CLIENT_ID?.trim();

--- a/src/lib/auth/baseURL.ts
+++ b/src/lib/auth/baseURL.ts
@@ -1,0 +1,42 @@
+import { getBaseUrl } from './getBaseUrl';
+
+/** Hosts that may appear on www-proxied or CMS-direct Better Auth requests. */
+export const AUTH_ALLOWED_HOSTS: string[] = [
+  'itsmillertime.dev',
+  '*.itsmillertime.dev',
+  'localhost',
+  'localhost:*',
+  '127.0.0.1',
+  '127.0.0.1:*',
+];
+
+export function resolveAuthBaseUrl(): string {
+  return getBaseUrl().replace(/\/+$/, '');
+}
+
+/**
+ * Static BETTER_AUTH_URL ignores X-Forwarded-Host, so www-proxied OAuth always
+ * built redirect_uri for cms. Dynamic config uses the browser host instead.
+ */
+export function getDynamicAuthBaseURL(): {
+  allowedHosts: string[];
+  protocol: 'auto';
+  fallback: string;
+} {
+  return {
+    allowedHosts: AUTH_ALLOWED_HOSTS,
+    protocol: 'auto',
+    fallback: resolveAuthBaseUrl(),
+  };
+}
+
+export function crossSubDomainForBaseUrl(baseUrl: string): string | null {
+  try {
+    const host = new URL(baseUrl).hostname;
+    return host === 'itsmillertime.dev' || host.endsWith('.itsmillertime.dev')
+      ? '.itsmillertime.dev'
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/auth/browserHost.ts
+++ b/src/lib/auth/browserHost.ts
@@ -1,0 +1,9 @@
+export const AUTH_BROWSER_HOST_HEADER = 'x-auth-browser-host';
+export const AUTH_BROWSER_PROTO_HEADER = 'x-auth-browser-proto';
+
+const ALLOWED_BROWSER_HOST =
+  /^(?:[a-z0-9-]+\.)*itsmillertime\.dev(?::\d+)?$|^(?:localhost|127\.0\.0\.1)(?::\d+)?$/i;
+
+export function isAllowedAuthBrowserHost(host: string): boolean {
+  return ALLOWED_BROWSER_HOST.test(host.trim());
+}

--- a/src/plugins/better-auth.ts
+++ b/src/plugins/better-auth.ts
@@ -1,5 +1,9 @@
 import { createBetterAuthOptions } from '@/lib/auth/config';
-import { getBaseUrl } from '@/lib/auth/getBaseUrl';
+import {
+  crossSubDomainForBaseUrl,
+  getDynamicAuthBaseURL,
+  resolveAuthBaseUrl,
+} from '@/lib/auth/baseURL';
 import { betterAuth } from 'better-auth';
 import {
   betterAuthCollections,
@@ -19,21 +23,6 @@ const userLinkedCollections: { collection: CollectionSlug; field: string }[] = [
   { collection: 'twoFactors', field: 'user' },
   { collection: 'passkeys', field: 'user' },
 ];
-
-function resolveAuthBaseUrl(): string {
-  return getBaseUrl().replace(/\/+$/, '');
-}
-
-function crossSubDomainForBaseUrl(baseUrl: string): string | null {
-  try {
-    const host = new URL(baseUrl).hostname;
-    return host === 'itsmillertime.dev' || host.endsWith('.itsmillertime.dev')
-      ? '.itsmillertime.dev'
-      : null;
-  } catch {
-    return null;
-  }
-}
 
 export function betterAuthPlugin() {
   return [
@@ -71,8 +60,8 @@ export function betterAuthPlugin() {
       autoRegisterEndpoints: true,
       createAuth: (payload) => {
         // Resolve at auth-init time (not module load) so Coolify runtime env is used.
-        const baseUrl = resolveAuthBaseUrl();
-        const crossSubDomain = crossSubDomainForBaseUrl(baseUrl);
+        const fallbackBaseUrl = resolveAuthBaseUrl();
+        const crossSubDomain = crossSubDomainForBaseUrl(fallbackBaseUrl);
 
         return betterAuth({
           ...createBetterAuthOptions(payload),
@@ -95,7 +84,9 @@ export function betterAuthPlugin() {
                 }
               : {}),
           },
-          baseURL: baseUrl,
+          // Static BETTER_AUTH_URL always won over X-Forwarded-Host, so Authentik
+          // authorize used the CMS callback even when login started on www.
+          baseURL: getDynamicAuthBaseURL(),
           secret: process.env.BETTER_AUTH_SECRET,
           user: {
             deleteUser: {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  AUTH_BROWSER_HOST_HEADER,
+  AUTH_BROWSER_PROTO_HEADER,
+  isAllowedAuthBrowserHost,
+} from '@/lib/auth/browserHost';
+
+/**
+ * Cloudflare / Coolify overwrite X-Forwarded-Host to cms when www proxies
+ * /api/auth over the public CMS URL. Restore the browser host from a header
+ * they do not touch so Better Auth can build redirect_uri for www.
+ */
+export function proxy(request: NextRequest) {
+  const browserHost = request.headers.get(AUTH_BROWSER_HOST_HEADER)?.split(',')[0]?.trim();
+  if (!browserHost || !isAllowedAuthBrowserHost(browserHost)) {
+    return NextResponse.next();
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set('x-forwarded-host', browserHost);
+
+  const proto = request.headers.get(AUTH_BROWSER_PROTO_HEADER)?.split(',')[0]?.trim();
+  if (proto === 'http' || proto === 'https') {
+    headers.set('x-forwarded-proto', proto);
+  }
+
+  return NextResponse.next({ request: { headers } });
+}
+
+export const config = {
+  matcher: '/api/auth/:path*',
+};


### PR DESCRIPTION
## Summary
- Switch Better Auth from a static `BETTER_AUTH_URL` (always cms) to a dynamic `baseURL` with `allowedHosts`, so `X-Forwarded-Host` from the www proxy actually changes `redirect_uri`.
- Add a Next.js `proxy.ts` that restores `x-forwarded-host` from `x-auth-browser-host` when Cloudflare/Coolify overwrite it.
- Admin login on cms is unchanged: no www forwarded host, fallback remains `BETTER_AUTH_URL`.

## Test plan
- [ ] Deploy this CMS PR, then the www companion PR (`/api/auth` internal proxy).
- [ ] `GET https://www.itsmillertime.dev/account/login/authentik` must show `redirect_uri=https://www.itsmillertime.dev/api/auth/oauth2/callback/authentik`.
- [ ] Android Chrome on **www** (not apex): complete Authentik and stay logged in.
- [ ] Payload admin Authentik login still callbacks to cms.


Made with [Cursor](https://cursor.com)